### PR TITLE
Fix/fonts in production

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,10 +14,6 @@
  *= require_self
  */
 
-$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
-@import '@fortawesome/fontawesome-free/scss/fontawesome';
-@import '@fortawesome/fontawesome-free/scss/regular';
-@import '@fortawesome/fontawesome-free/scss/solid';
 @import 'bootstrap/scss/bootstrap';
 
 .hexlet-cv-inline-paragraph {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,9 +14,10 @@ require('bootstrap');
 require('./cocoon');
 
 import { library, dom } from '@fortawesome/fontawesome-svg-core'
-import { fonts } from './fontAwesome'
+import { fas } from '@fortawesome/free-solid-svg-icons'
+import { far } from '@fortawesome/free-regular-svg-icons'
 
-library.add(...fonts)
+library.add(fas, far)
 
 dom.watch()
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,14 @@ require('popper.js');
 require('bootstrap');
 require('./cocoon');
 
+import { library, dom } from '@fortawesome/fontawesome-svg-core'
+import { fas } from '@fortawesome/free-solid-svg-icons'
+import { far } from '@fortawesome/free-regular-svg-icons'
+
+library.add(fas, far)
+
+dom.watch()
+
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,10 +14,9 @@ require('bootstrap');
 require('./cocoon');
 
 import { library, dom } from '@fortawesome/fontawesome-svg-core'
-import { fas } from '@fortawesome/free-solid-svg-icons'
-import { far } from '@fortawesome/free-regular-svg-icons'
+import { fonts } from './fontAwesome'
 
-library.add(fas, far)
+library.add(...fonts)
 
 dom.watch()
 

--- a/app/javascript/packs/fontAwesome.js
+++ b/app/javascript/packs/fontAwesome.js
@@ -1,0 +1,9 @@
+import { faEdit as fasEdit, faThumbsUp as fasThumbsUp } from '@fortawesome/free-solid-svg-icons'
+import { faEdit as farEdit, faThumbsUp as farThumbsUp } from '@fortawesome/free-regular-svg-icons'
+
+export const fonts = [
+  fasEdit,
+  farEdit,
+  fasThumbsUp,
+  farThumbsUp
+]

--- a/app/javascript/packs/fontAwesome.js
+++ b/app/javascript/packs/fontAwesome.js
@@ -1,9 +1,0 @@
-import { faEdit as fasEdit, faThumbsUp as fasThumbsUp } from '@fortawesome/free-solid-svg-icons'
-import { faEdit as farEdit, faThumbsUp as farThumbsUp } from '@fortawesome/free-regular-svg-icons'
-
-export const fonts = [
-  fasEdit,
-  farEdit,
-  fasThumbsUp,
-  farThumbsUp
-]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "dependencies": {
     "@babel/preset-react": "^7.0.0",
     "@fortawesome/fontawesome-free": "^5.10.2",
+    "@fortawesome/fontawesome-svg-core": "^1.2.22",
+    "@fortawesome/free-regular-svg-icons": "^5.10.2",
+    "@fortawesome/free-solid-svg-icons": "^5.10.2",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,10 +746,36 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-common-types@^0.2.22":
+  version "0.2.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.22.tgz#3f1328d232a0fd5de8484d833c8519426f39f016"
+  integrity sha512-QmEuZsipX5/cR9JOg0fsTN4Yr/9lieYWM8AQpmRa0eIfeOcl/HLYoEa366BCGRSrgNJEexuvOgbq9jnJ22IY5g==
+
 "@fortawesome/fontawesome-free@^5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.10.2.tgz#27e02da1e34b50c9869179d364fb46627b521130"
   integrity sha512-9pw+Nsnunl9unstGEHQ+u41wBEQue6XPBsILXtJF/4fNN1L3avJcMF/gGF86rIjeTAgfLjTY9ndm68/X4f4idQ==
+
+"@fortawesome/fontawesome-svg-core@^1.2.22":
+  version "1.2.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.22.tgz#9a6117c96c8b823c7d531000568ac75c3c02e123"
+  integrity sha512-Q941E4x8UfnMH3308n0qrgoja+GoqyiV846JTLoCcCWAKokLKrixCkq6RDBs8r+TtAWaLUrBpI+JFxQNX/WNPQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.22"
+
+"@fortawesome/free-regular-svg-icons@^5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.10.2.tgz#e4ada1c15f42133ad92761418a9b0e2d407fb022"
+  integrity sha512-Qk4FmwXuRDY5K2GyiKt7adCN204dTlTb0Ps3/JU4BfYoCrU43DResd1QZxfcoQJfV2kw29spZ4+BDL+9IRyj1Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.22"
+
+"@fortawesome/free-solid-svg-icons@^5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.10.2.tgz#61bcecce3aa5001fd154826238dfa840de4aa05a"
+  integrity sha512-9Os/GRUcy+iVaznlg8GKcPSQFpIQpAg14jF0DWsMdnpJfIftlvfaQCWniR/ex9FoOpSEOrlXqmUCFL+JGeciuA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.22"
 
 "@rails/actioncable@^6.0.0":
   version "6.0.0"


### PR DESCRIPTION
PR исправляет проблему загрузки шрифтов Font Awesome, установленных в node_modules, путем замены <i>  на <svg>
Импортируются только иконки, которые используются в приложении, чтобы уменьшить размер bundle
