### PR TITLE
fix resume text truncate

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,10 @@ module ApplicationHelper
     markdown.render(text)
   end
 
+  def truncate_markdown(text, options)
+    truncate(strip_tags(markdown2html(text)), options)
+  end
+
   def active?(path, options = {})
     # raise options.inspect
     if options.key? :active_if

--- a/app/views/web/home/index.html.slim
+++ b/app/views/web/home/index.html.slim
@@ -14,7 +14,7 @@
           /   .small= t('.likes')
         div
           h5.card-title= link_to resume, resume_path(resume)
-          .card-text== markdown2html truncate(resume.summary, length: 200)
+          .card-text= truncate(strip_tags(markdown2html(resume.summary)), length: 200)
           .text-right.small
             span.mr-3.text-muted
               = distance_of_time_in_words_to_now resume.created_at

--- a/app/views/web/home/index.html.slim
+++ b/app/views/web/home/index.html.slim
@@ -14,7 +14,7 @@
           /   .small= t('.likes')
         div
           h5.card-title= link_to resume, resume_path(resume)
-          .card-text= truncate(strip_tags(markdown2html(resume.summary)), length: 200)
+          .card-text= truncate_markdown(resume.summary, length: 200)
           .text-right.small
             span.mr-3.text-muted
               = distance_of_time_in_words_to_now resume.created_at


### PR DESCRIPTION
Лажанул немного с обрезанием

<img width="491" alt="Screenshot 2019-10-10 at 10 33 35 PM" src="https://user-images.githubusercontent.com/14975453/66596583-348cf280-ebae-11e9-9d21-292e0d933721.png">

После фикса будет так
<img width="611" alt="Screenshot 2019-10-10 at 10 33 42 PM" src="https://user-images.githubusercontent.com/14975453/66596558-2f2fa800-ebae-11e9-9056-f051d966967e.png">
