### PR TITLE
Add code coverage with SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ doc
 # Ignore docker and docker-compose files
 Dockerfile
 docker-compose.yml
+
+# Ignore coverage files
+/coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+SimpleCov.profiles.define 'custom rails' do
+  add_filter '/config/'
+  add_filter 'test'
+  add_filter 'vendor'
+
+  add_group 'Models', 'app/models'
+  add_group 'Mutators', 'app/mutators'
+  add_group 'Policies', 'app/policies'
+  add_group 'Repositories', 'app/repositories'
+  add_group 'Libraries', 'lib'
+
+  add_group 'Web/Controllers', 'app/controllers/web'
+  add_group 'Web/Helpers', 'app/helpers/web'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'minitest-power_assert'
+  gem 'simplecov', require: false
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'

--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
   gem 'minitest-power_assert'
-  gem 'simplecov', require: false
   gem 'selenium-webdriver'
+  gem 'simplecov', require: false
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     devise-bootstrap-views (1.1.0)
     devise-i18n (1.8.2)
       devise (>= 4.6)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -145,6 +146,7 @@ GEM
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    json (2.2.0)
     jwt (2.2.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -304,6 +306,11 @@ GEM
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -413,6 +420,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   simple_form
+  simplecov
   slim-rails
   solargraph
   spring

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+if ENV['COVERAGE']
+  require 'simplecov'
+
+  SimpleCov.start 'custom rails'
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'


### PR DESCRIPTION
Добавил анализатор покрытия кода тестами, используя gem [simplecov](https://github.com/colszowka/simplecov).

Запустить локально тесты с созданием отчёта по покрытию:

```bash
$ COVERAGE=true make test

```

Посмотреть результаты можно в браузере, открыв файл `file:///{path_to_project_root}/coverage/index.html`, который лежит в директории `coverage` проекта.