### PR TITLE
Add Code Climate test reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ install:
   - npm i -g yarn
   - yarn
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script:
   - make lint
   - make test
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
Добавил отправку результата выполнения тестов в Code Climate.

Нужно только добавить в настройках Travis'а две переменные окружения для репозитория:
- `CC_TEST_REPORTER_ID=<cc_test_reporter_id>` (генерируется в Code Climate -> Test coverage)
- `COVERAGE=true`