### PR TITLE
Fix Rubocop checks in Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,7 @@ version: "2"
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-74
   brakeman:
     enabled: true
   reek:


### PR DESCRIPTION
Пофиксил [ошибку](https://codeclimate.com/github/Hexlet/hexlet-cv/builds/657) при запуске `rubocop`'а в Code Climate:

```
/usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:122:in `require': cannot load such file -- rubocop-performance (LoadError)
	from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:122:in `require'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader_resolver.rb:15:in `block in resolve_requires'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader_resolver.rb:11:in `each'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader_resolver.rb:11:in `resolve_requires'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader.rb:38:in `load_file'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_loader.rb:79:in `configuration_from_file'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/config_store.rb:44:in `for'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:161:in `excluded_dirs'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:139:in `find_files'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:112:in `target_files_in_dir'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:89:in `block in find'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:87:in `each'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/target_finder.rb:87:in `find'
	from /usr/local/bundle/gems/rubocop-0.52.1/lib/rubocop/runner.rb:58:in `find_target_files'
	from /usr/src/app/lib/cc/engine/file_list_resolver.rb:15:in `block in expanded_list'
	from /usr/src/app/lib/cc/engine/file_list_resolver.rb:13:in `each'
	from /usr/src/app/lib/cc/engine/file_list_resolver.rb:13:in `flat_map'
	from /usr/src/app/lib/cc/engine/file_list_resolver.rb:13:in `expanded_list'
	from /usr/src/app/lib/cc/engine/rubocop.rb:49:in `files_to_inspect'
	from /usr/src/app/lib/cc/engine/rubocop.rb:29:in `block in run'
	from /usr/src/app/lib/cc/engine/rubocop.rb:28:in `chdir'
	from /usr/src/app/lib/cc/engine/rubocop.rb:28:in `run'
	from /usr/src/app/bin/codeclimate-rubocop:17:in `<main>'
```

Останется только включить вебхуки в Code Climate (если ещё не включены), чтобы бейджики "ожили" 🎉.

Для справки - https://docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions