### PR TITLE
Change time range for "Popular" tab

### DIFF
--- a/app/views/web/home/index.html.slim
+++ b/app/views/web/home/index.html.slim
@@ -1,6 +1,6 @@
 .btn-group.mb-3
   = filter_link(t('.all'), {}, class: 'btn btn-light')
-  = filter_link(t('.popular'), { popular_gteq: Date.current - 1.day }, class: 'btn btn-light')
+  = filter_link(t('.popular'), { popular_gteq: Date.current - 1.week }, class: 'btn btn-light')
   = filter_link(t('.newest'), { created_at_gteq: Date.current - 1.day }, class: 'btn btn-light')
   = filter_link(t('.without_answers'), { answers_count_eq: 0 }, class: 'btn btn-light')
 


### PR DESCRIPTION
Problem:
* There are not enough resumes to display popular resumes over the last day
  consistently

Solution:
* Increase time range for popular resumes query