### PR TITLE
Fix pagination buttons

### DIFF
--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,2 +1,5 @@
 li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'
+  - unless current_page.first?
+    = link_to url, remote: remote, class: 'page-link' do
+      | &laquo;
+      span.d-none.d-lg-inline = t 'views.pagination.first'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,2 +1,5 @@
 li.page-item
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'
+  - unless current_page.last?
+    = link_to url, remote: remote, class: 'page-link' do
+      span.d-none.d-lg-inline = t 'views.pagination.last'
+      | &raquo;

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,2 +1,5 @@
 li.page-item
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'
+  - unless current_page.last?
+    = link_to url, rel: 'next', remote: remote, class: 'page-link' do
+      span.d-none.d-lg-inline = t 'views.pagination.next'
+      | &rsaquo;

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,5 +1,5 @@
 = paginator.render do
-  nav
+  nav.d-flex.justify-content-center
     ul.pagination
       == first_page_tag unless current_page.first?
       == prev_page_tag unless current_page.first?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,2 +1,5 @@
 li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'
+  - unless current_page.first?
+    = link_to url, rel: 'prev', remote: remote, class: 'page-link' do
+      | &lsaquo;
+      span.d-none.d-lg-inline = t 'views.pagination.previous'

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
       subject: You have a new recommendation
   views:
     pagination:
-      first: "&laquo; First"
-      last: "Last &raquo;"
-      previous: "&lsaquo; Prev"
-      next: "Next &rsaquo;"
+      first: " First"
+      last: "Last "
+      previous: " Prev"
+      next: "Next "
       truncate: "&hellip;"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -5,8 +5,8 @@ ru:
       subject: У вас новая рекомендация к резюме
   views:
     pagination:
-      first: "&laquo; Первая"
-      last: "Последняя &raquo;"
-      next: "Следующая &rsaquo;"
-      previous: "&lsaquo; Предыдущая"
+      first: " Первая"
+      last: "Последняя "
+      next: "Следующая "
+      previous: " Предыдущая"
       truncate: "&hellip;"


### PR DESCRIPTION
На малых экранах кнопки пагинации выходили за область, появлялась горизонтальная прокрутка. 

- Изменил содержимое кнопок, на малых экранах пропадают надписи, остается только стрелки.
- Отцентрировал сами кнопки относительно карточек.
- Уменьшил количество страниц доступных для пагинации.

До:
![before](https://user-images.githubusercontent.com/41317348/91273667-f1853f00-e7c0-11ea-8757-a339d6db899b.png)

После:
![after](https://user-images.githubusercontent.com/41317348/91273662-f0541200-e7c0-11ea-831b-f5f8a750c7be.png)

