### PR TITLE
imrpove require tag

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -3,11 +3,11 @@ en:
     "yes": 'Yes'
     "no": 'No'
     required:
-      text: 'required'
-      mark: '*'
+      # text: 'required'
+      # mark: '*'
       # You can uncomment the line below if you need to overwrite the whole required html.
       # When using html, text and mark won't be used.
-      # html: '<abbr title="required">*</abbr>'
+      html: '<span title="required">*</span>'
     error_notification:
       default_message: "Please review the problems below:"
     # Examples

--- a/config/locales/simple_form.ru.yml
+++ b/config/locales/simple_form.ru.yml
@@ -1,5 +1,11 @@
 ru:
   simple_form:
+    required:
+      # text: 'required'
+      # mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      html: '<span title="обязательно">*</span>'
     labels:
       q:
         first_name_or_last_name_or_email_cont: Вхождение по имени, фамилии, почте


### PR DESCRIPTION
from: 
![image](https://user-images.githubusercontent.com/23584933/136962724-93cd77be-57f1-4391-aefd-02493f5e2adb.png)

to:
![image](https://user-images.githubusercontent.com/23584933/136962753-4da48023-8959-4ba2-a1b5-efd5d75aabf6.png)

По-дефолту выводится abbr тег, который бутстрапом не красиво выделяется
Простой спан решает все проблемы (и это даже семантичнее)