### PR TITLE
fix admin search form

### DIFF
--- a/app/views/web/admin/users/index.html.slim
+++ b/app/views/web/admin/users/index.html.slim
@@ -1,6 +1,6 @@
 .p-3.mb-3.bg-light
   = search_form_for @q, default_filter_form_options(url: admin_users_path) do |f|
-    = f.input :first_name_or_last_name_or_email_cont
+    = f.input :first_name_or_last_name_or_email_cont, as: :string
     .col-auto.d-flex
       .mt-auto
         = f.button :submit, class: 'btn-primary me-2'


### PR DESCRIPTION
Если в поиске есть поиск по email, то формируется инпут с типом `email`, что не дает искать по имени
[скрин](https://user-images.githubusercontent.com/697178/138940839-2ef8568d-445f-4ae4-a2c6-d618c8ae8d0b.png)
