### PR TITLE
Fix salary to validation stored vacancies

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -26,10 +26,10 @@ class Vacancy < ApplicationRecord
   validates :employment_type, presence: true
   validates :salary_from, presence: true,
                           numericality: { only_integer: true, greater_than: 0 },
-                          unless: -> { salary_to&.positive? }
+                          unless: -> { salary_amount_type.depends? || salary_to&.positive? }
   validates :salary_to, presence: true,
                         numericality: { only_integer: true, greater_than: 0 },
-                        unless: -> { salary_from&.positive? }
+                        unless: -> { salary_amount_type.depends? || salary_from&.positive? }
   validates :salary_currency, presence: true
   # validates :programming_language, presence: true
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -26,10 +26,10 @@ class Vacancy < ApplicationRecord
   validates :employment_type, presence: true
   validates :salary_from, presence: true,
                           numericality: { only_integer: true, greater_than: 0 },
-                          unless: -> { salary_amount_type.depends? || salary_to&.positive? }
+                          unless: -> { salary_amount_type == :depends || salary_to&.positive? }
   validates :salary_to, presence: true,
                         numericality: { only_integer: true, greater_than: 0 },
-                        unless: -> { salary_amount_type.depends? || salary_from&.positive? }
+                        unless: -> { salary_amount_type == :depends || salary_from&.positive? }
   validates :salary_currency, presence: true
   # validates :programming_language, presence: true
 

--- a/db/migrate/20220217153126_fix_vacancies_without_salary.rb
+++ b/db/migrate/20220217153126_fix_vacancies_without_salary.rb
@@ -1,0 +1,13 @@
+class FixVacanciesWithoutSalary < ActiveRecord::Migration[6.1]
+  def change
+    Vacancy.find_each do |v|
+      should_update = !v.salary_amount_type.depends? && v.salary_to.nil? && v.salary_from.nil?
+
+      next if !should_update
+
+      v.salary_amount_type = :depends
+
+      v.save!
+    end
+  end
+end

--- a/test/factories/vacancies.rb
+++ b/test/factories/vacancies.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     contact_telegram { 'MyString' }
     contact_phone { 'MyString' }
     responsibilities_description { 'MyString' }
+    salary_amount_type { :net }
   end
 end

--- a/test/fixtures/vacancies.yml
+++ b/test/fixtures/vacancies.yml
@@ -32,3 +32,9 @@ php-developer:
   title: PHP-разработчик
   creator: full
   salary_to: 3000
+
+vacancy-depends-salary:
+  <<: *DEFAULTS
+  title: Yoptascript-developer
+  creator: full
+  salary_amount_type: :depends

--- a/test/fixtures/vacancies.yml
+++ b/test/fixtures/vacancies.yml
@@ -7,6 +7,7 @@ DEFAULTS: &DEFAULTS
   site: https://www.hexlet.io
   city_name: москва
   position_level: junior
+  salary_amount_type: :net
 
 one:
   <<: *DEFAULTS


### PR DESCRIPTION
Фикс логики для зарплат.
Ранее можно было создать вакансию без указания зарплат (от до), для отображения зп по договорённости.
Сейчас для этого есть отдельное значение. В БД 48 вакансий не того типа, но без зп от\до
closes #322 #318 