### PR TITLE
Add nodejs version limit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## System requirements
 
 * Ruby
-* Node.js
+* Node.js, '< 17.0.0'
 * Yarn
 * SQLite3
 * [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#download-and-install)


### PR DESCRIPTION
If nodejs >= 17.0.0 used, then "make start" will return
error:0308010C:digital envelope routines::unsupported