### PR TITLE
[#335] Fixed incorrect behavior of the vacancy filter

### DIFF
--- a/app/controllers/web/vacancy_filters_controller.rb
+++ b/app/controllers/web/vacancy_filters_controller.rb
@@ -48,7 +48,7 @@ class Web::VacancyFiltersController < Web::ApplicationController
     search_id = form.to_search_id
     redirect_url = search_id.blank? ? vacancies_url : vacancy_filter_url({ id: search_id })
 
-    redirect_to redirect_url
+    redirect_to "#{redirect_url}#{'&format=html' if search_id.include?('.')}"
   end
 
   private
@@ -58,7 +58,8 @@ class Web::VacancyFiltersController < Web::ApplicationController
   end
 
   def fetch_options(params)
-    options = params.split('_').map { |value| value.split('-', 2) }
+    options =
+      params.gsub('&format=html', '').split('_').map { |value| value.split('-', 2) }
     if options.filter { |_k, v| v.blank? }.any?
       raise ActionController::RoutingError, 'Not Found'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   scope module: :web do
     root 'home#index'
     resources :vacancies, only: %i[index show]
-    resources :vacancy_filters, only: %i[show] do
+    resources :vacancy_filters, only: %i[show], constraints: { id: %r{[^/]+} } do
       collection do
         get :search
       end


### PR DESCRIPTION
If in the search for vacancies in the field 'direction' a value with a dot was selected,
 for example, node.js, react.js, etc., then the filter did not work correctly.

There were 2 problems:
  1. The following path is declared in routes -
      web/vacancy_filters#search vacancy_filter GET /vacancy_filters/:id(.:format).
     So, :id equal to 'direction-node' and format equal to 'js' were formed from the
      passed path 'https://cv.hexlet.io/vacancy_filters/direction-node.js'.
     With such value of :id, obviously, the filter did not work correctly,
      searching by 'node' value.
     How was it solved? Was added route constraints to remove dot separation, so
      new :id in our example will be equal 'direction-node.js' - the filter will work correctly.

  2. Regardless of whether we fixed the first problem, styles were not loading.
     Action 'search' in vacancy_filters_controller.rb:46 redirected_to action 'show' in vacancy_filters_controller.rb:4, and request was                 js-format.
     We need 'html' to load styles from front-server. Format of request was
      defined in action_dispatch/http/mime_negotiation.rb.
     Our case is 'format_from_path_extension', so format from 'https://cv.hexlet.io/vacancy_filters/direction-node.js' will be 'js'.
     How was it solved? In fact, this is a crutch, but we can pass the format in the parameters if
      search_id contains '.', like 'https://cv.hexlet.io/vacancy_filters/direction-node.js&format=html' -
      so we get into condition 'params_readable?' and 'Array(Mime[parameters[:format]])' return 'html'.
     Then in fetch_options we remove that service parameter. So, format is correct and styles are loaded.