### PR TITLE
[#335] Fixed incorrect behavior of the vacancy filter

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,10 @@ Rails.application.routes.draw do
   scope module: :web do
     root 'home#index'
     resources :vacancies, only: %i[index show]
-    resources :vacancy_filters, only: %i[show] do
+    # FIXME: фикс дирекшенов с точками типа node.js, убрать, когда определимся, нужно ли будем валидировать направления и запретим указывать точки
+    resources :vacancy_filters, only: %i[show], constraints: { id: %r{[^/]+} }, format: false, defaults: { format: 'html' } do
       collection do
-        get :search
+        get :search, format: true
       end
     end
     resources :resumes do


### PR DESCRIPTION
If in the search for vacancies in the field 'direction' a value with a dot was selected,
 for example, node.js, react.js, etc., then the filter did not work correctly.

There were 2 problems:
  1. The following path is declared in routes -
      web/vacancy_filters#search vacancy_filter GET /vacancy_filters/:id(.:format).
     So, :id equal to 'direction-node' and format equal to 'js' were formed from the
      passed path 'https://cv.hexlet.io/vacancy_filters/direction-node.js'.
     With such value of :id, obviously, the filter did not work correctly,
      searching by 'node' value.
     How was it solved? Was added route constraints to remove dot separation, so
      new :id in our example will be equal 'direction-node.js' - the filter will work correctly.

  2. Regardless of whether we fixed the first problem, styles were not loading.
     Action 'search' in vacancy_filters_controller.rb:46 redirected_to action 'show' in vacancy_filters_controller.rb:4, and request was js-format. We need 'html' to load styles from front-server. Format of request defined in action_dispatch/http/mime_negotiation.rb. Our case is 'format_from_path_extension', so format from 'https://cv.hexlet.io/vacancy_filters/direction-node.js' will be 'js'.
     How was it solved? We set default format 'html' to our route - then we get into condition 'params_readable?' and 'Array(Mime[parameters[:format]])' return 'html'. So, format is correct and styles are loaded.