### PR TITLE
Setting up notifications with Hexlet CV

### DIFF
--- a/app/controllers/web/answers/comments_controller.rb
+++ b/app/controllers/web/answers/comments_controller.rb
@@ -23,6 +23,7 @@ class Web::Answers::CommentsController < Web::Answers::ApplicationController
     form = Web::Resumes::Answers::CommentForm.new(answer_comment_params)
     @comment = Resume::Answer::CommentMutator.create(resource_answer, form.attributes, current_user)
     if @comment.persisted?
+      @comment.send_new_comment_email
       f(:success)
       redirect_to resume_path(resource_answer.resume)
     else

--- a/app/controllers/web/resumes/comments_controller.rb
+++ b/app/controllers/web/resumes/comments_controller.rb
@@ -21,6 +21,7 @@ class Web::Resumes::CommentsController < Web::Resumes::ApplicationController
     form = Web::Resumes::CommentForm.new(resume_comment_params)
     @comment = Resume::CommentMutator.create(resource_resume, form.attributes, current_user)
     if @comment.persisted?
+      @comment.send_new_comment_email
       f(:success)
       redirect_to resume_path(resource_resume)
     else

--- a/app/mailers/answer_comment_mailer.rb
+++ b/app/mailers/answer_comment_mailer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AnswerCommentMailer < ApplicationMailer
+  def new_comment_email
+    @comment = params[:comment]
+
+    mail(to: @comment.answer.user.email, subject: t('.subject'))
+  end
+end

--- a/app/mailers/resume_comment_mailer.rb
+++ b/app/mailers/resume_comment_mailer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ResumeCommentMailer < ApplicationMailer
+  def new_comment_email
+    @comment = params[:comment]
+    mail(to: @comment.resume.user.email, subject: t('.subject'))
+  end
+end

--- a/app/models/resume/answer/comment.rb
+++ b/app/models/resume/answer/comment.rb
@@ -14,4 +14,10 @@ class Resume::Answer::Comment < ApplicationRecord
   def to_s
     content
   end
+
+  def send_new_comment_email
+    return nil unless resume.user.can_send_email? && resume.user.resume_mail_enabled
+
+    AnswerCommentMailer.with(comment: self).new_comment_email.deliver_later
+  end
 end

--- a/app/models/resume/comment.rb
+++ b/app/models/resume/comment.rb
@@ -11,4 +11,10 @@ class Resume::Comment < ApplicationRecord
   def to_s
     content
   end
+
+  def send_new_comment_email
+    return nil unless resume.user.can_send_email? && resume.user.resume_mail_enabled
+
+    ResumeCommentMailer.with(comment: self).new_comment_email.deliver_later
+  end
 end

--- a/app/views/answer_comment_mailer/new_comment_email.en.html.slim
+++ b/app/views/answer_comment_mailer/new_comment_email.en.html.slim
@@ -1,0 +1,14 @@
+p = sanitize t('.new_comment',
+      user_path: user_url(@comment.user),
+      user: "#{@comment.user.first_name} #{@comment.user.last_name}",
+      comment_path: resume_url(@comment.resume, anchor: "comment-#{@comment.id}"))
+hr
+
+p = t('.content')
+
+p
+  = @comment.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/app/views/answer_comment_mailer/new_comment_email.ru.html.slim
+++ b/app/views/answer_comment_mailer/new_comment_email.ru.html.slim
@@ -1,0 +1,14 @@
+p = sanitize t('.new_comment',
+      user_path: user_url(@comment.user),
+      user: "#{@comment.user.first_name} #{@comment.user.last_name}",
+      comment_path: resume_url(@comment.resume, anchor: "comment-#{@comment.id}"))
+hr
+
+p = t('.content')
+
+p
+  = @comment.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/app/views/resume_answer_mailer/new_answer_email.en.html.erb
+++ b/app/views/resume_answer_mailer/new_answer_email.en.html.erb
@@ -1,7 +1,0 @@
-<p>
-  <%= link_to @answer.user, user_url(@answer.user), target: "_blank" %> left a recommendation on your CV <%= link_to @answer.resume, resume_url(@answer.resume, anchor: "answer-#{@answer.id}"), target: "_blank" %>
-</p>
-
-<p>
-  You can unsubscribe from resume newsletters at <%= link_to 'settings', account_profile_url, target: "_blank" %>
-</p>

--- a/app/views/resume_answer_mailer/new_answer_email.en.html.slim
+++ b/app/views/resume_answer_mailer/new_answer_email.en.html.slim
@@ -1,0 +1,17 @@
+h2 = t('.review')
+
+p = sanitize t('.new_answer',
+      user_path: user_url(@answer.user),
+      user: "#{@answer.user.first_name} #{@answer.user.last_name}",
+      answer_path: resume_url(@answer.resume, anchor: "answer-#{@answer.id}"))
+
+hr
+
+p = t('.content')
+
+p
+  = @answer.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/app/views/resume_answer_mailer/new_answer_email.ru.html.erb
+++ b/app/views/resume_answer_mailer/new_answer_email.ru.html.erb
@@ -1,7 +1,0 @@
-<p>
-  <%= link_to @answer.user, user_url(@answer.user), target: "_blank" %> оставил рекомендацию в вашему резюме <%= link_to @answer.resume, resume_url(@answer.resume, anchor: "answer-#{@answer.id}"), target: "_blank" %>
-</p>
-
-<p>
-  Вы можете отписаться от рассылки в <%= link_to 'настройках', account_profile_url, target: "_blank" %>
-</p>

--- a/app/views/resume_answer_mailer/new_answer_email.ru.html.slim
+++ b/app/views/resume_answer_mailer/new_answer_email.ru.html.slim
@@ -1,0 +1,17 @@
+h2 = t('.review')
+
+p = sanitize t('.new_answer',
+      user_path: user_url(@answer.user),
+      user: "#{@answer.user.first_name} #{@answer.user.last_name}",
+      answer_path: resume_url(@answer.resume, anchor: "answer-#{@answer.id}"))
+
+hr
+
+p = t('.content')
+
+p
+  = @answer.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/app/views/resume_comment_mailer/new_comment_email.en.html.slim
+++ b/app/views/resume_comment_mailer/new_comment_email.en.html.slim
@@ -1,0 +1,15 @@
+p = sanitize t('.new_comment',
+      user_path: user_url(@comment.user),
+      user: "#{@comment.user.first_name} #{@comment.user.last_name}",
+      comment_path: resume_url(@comment.resume, anchor: "comment-#{@comment.id}"))
+
+hr
+
+p = t('.content')
+
+p
+  = @comment.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/app/views/resume_comment_mailer/new_comment_email.ru.html.slim
+++ b/app/views/resume_comment_mailer/new_comment_email.ru.html.slim
@@ -1,0 +1,15 @@
+p = sanitize t('.new_comment',
+      user_path: user_url(@comment.user),
+      user: "#{@comment.user.first_name} #{@comment.user.last_name}",
+      comment_path: resume_url(@comment.resume, anchor: "comment-#{@comment.id}"))
+
+hr
+
+p = t('.content')
+
+p
+  = @comment.content
+
+hr
+
+p  #{t('.unsubscribe')} #{link_to t('.settings'), account_profile_url, target: '_blank', rel: 'noopener'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,9 +12,28 @@ en:
   date:
     formats:
       discard_day: '%b %Y'
+  answer_comment_mailer:
+    new_comment_email:
+      content: 'Content:'
+      new_comment: The user <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> left <a href="%{comment_path}">a new comment</a> on your summary
+      unsubscribe: You can unsubscribe from the newsletter in
+      settings: settings
+      subject: New comment for your recommendation.
   resume_answer_mailer:
     new_answer_email:
+      content: 'Content:'
+      new_answer: The user <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> left <a href="%{answer_path}">a new recommendation</a> to your summary
+      review: Your resume has been reviewed!
+      unsubscribe: You can unsubscribe from the newsletter in
+      settings: settings
       subject: You have a new recommendation
+  resume_comment_mailer:
+    new_comment_email:
+      content: 'Content:'
+      new_comment: The user <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> left <a href="%{comment_path}">a new comment</a> on your summary
+      unsubscribe: You can unsubscribe from the newsletter in
+      settings: settings
+      subject: You have a new resume comment
   reset: Reset
   submit: Submit
   search: Search

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -11,9 +11,28 @@ ru:
   in_the_city: "в городе %{city_name}"
   remote_job: Удаленная работа
   confirm: Вы уверены?
+  answer_comment_mailer:
+    new_comment_email:
+      content: 'Содержание:'
+      new_comment: Пользователь <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> оставил <a href="%{comment_path}">новый комментарий</a> к вашему резюме
+      unsubscribe: Вы можете отписаться от рассылки в
+      settings: настройках
+      subject: К вашей рекомендайии ноый коментарий.
+  resume_comment_mailer:
+    new_comment_email:
+      content: 'Содержание:'
+      new_comment: Пользователь <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> оставил <a href="%{comment_path}">новый комментарий</a> к вашему резюме
+      unsubscribe: Вы можете отписаться от рассылки в
+      settings: настройках
+      subject: У вас новый коментарий к резюме
   resume_answer_mailer:
     new_answer_email:
+      content: 'Содержание:'
+      new_answer: Пользователь <a href="%{user_path}" class="text-secondary fw-bolder">%{user}</a> оставил <a href="%{answer_path}">новую рекомендацию</a> к вашему резюме
+      review: Ваше резюме прошло ревью!
       subject: У вас новая рекомендация к резюме
+      unsubscribe: Вы можете отписаться от рассылки в
+      settings: настройках
   reset: Сбросить
   submit: Отправить
   search: Найти
@@ -24,3 +43,4 @@ ru:
       next: "Следующая "
       previous: " Предыдущая"
       truncate: "&hellip;"
+    

--- a/test/mailers/answer_comment_mailer_test.rb
+++ b/test/mailers/answer_comment_mailer_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AnswerCommentMailerTest < ActionMailer::TestCase
+  test 'new comment' do
+    comment = resume_answer_comments(:one)
+    mail = AnswerCommentMailer.with(comment:).new_comment_email
+    assert { comment.answer.user.email == mail.to.first }
+  end
+end

--- a/test/mailers/previews/answer_comment_mailer_preview.rb
+++ b/test/mailers/previews/answer_comment_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/answer_comment_mailer
+class AnswerCommentMailerPreview < ActionMailer::Preview
+  def new_comment_email
+    AnswerCommentMailer.with(comment: Resume::Answer::Comment.first).new_comment_email
+  end
+end

--- a/test/mailers/previews/resume_comment_mailer_preview.rb
+++ b/test/mailers/previews/resume_comment_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/resume_comment_mailer
+class ResumeCommentMailerPreview < ActionMailer::Preview
+  def new_comment_email
+    ResumeCommentMailer.with(comment: Resume::Comment.first).new_comment_email
+  end
+end

--- a/test/mailers/resume_answer_mailer_test.rb
+++ b/test/mailers/resume_answer_mailer_test.rb
@@ -3,7 +3,9 @@
 require 'test_helper'
 
 class ResumeAnswerMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'new answer' do
+    answer = resume_answers(:one)
+    mail = ResumeAnswerMailer.with(answer:).new_answer_email
+    assert { answer.resume.user.email == mail.to.first }
+  end
 end

--- a/test/mailers/resume_comment_mailer_test.rb
+++ b/test/mailers/resume_comment_mailer_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResumeCommentMailerTest < ActionMailer::TestCase
+  test 'new comment' do
+    comment = resume_comments(:one)
+    mail = ResumeCommentMailer.with(comment:).new_comment_email
+    assert { comment.resume.user.email == mail.to.first }
+  end
+end


### PR DESCRIPTION
https://github.com/Hexlet/hexlet-cv/issues/355

Что сделал:
  1.  добавил 2 майлера resume_comment_mailer и answer_comment_mailer
  2. добавил шаблоны писем, переделал старый шаблон resume_answer под slim(был erb)
  3. добавил локали
  4. несколько тестов для для майлеров
  5. все протестировал через mailtrap
  6. 
 локаль для subject добавил)
![Снимок экрана от 2022-09-16 15-30-11](https://user-images.githubusercontent.com/48034349/190640055-0c2369b1-3dff-4d73-9b7a-60db8568a929.png)

![Снимок экрана от 2022-09-16 15-30-14](https://user-images.githubusercontent.com/48034349/190640287-2b45cc98-383f-47b4-9955-d80f6cf045f5.png)

![Снимок экрана от 2022-09-16 15-40-00](https://user-images.githubusercontent.com/48034349/190640867-60948725-ca3c-4ba1-88e6-28a370a8251b.png)


