### PR TITLE
add filter_link for vacancies tags

### DIFF
--- a/app/controllers/web/vacancies_controller.rb
+++ b/app/controllers/web/vacancies_controller.rb
@@ -2,7 +2,8 @@
 
 class Web::VacanciesController < Web::ApplicationController
   def index
-    @vacancies = Vacancy.web.page(params[:page])
+    q = Vacancy.web.ransack(params[:q])
+    @vacancies = q.result(distinct: true).page(params[:page])
     @vacancy_search_form = Web::Vacancies::SearchForm.new
     @tags = Vacancy.tags_sorted_list
     @page = params[:page]

--- a/app/controllers/web/vacancy_filters_controller.rb
+++ b/app/controllers/web/vacancy_filters_controller.rb
@@ -41,7 +41,7 @@ class Web::VacancyFiltersController < Web::ApplicationController
 
     @vacancy_search_form = Web::Vacancies::SearchForm.new(prepare_options_for_search_form(@options))
     @tags = Vacancy.tags_sorted_list
-    @vacancies = scope
+    @vacancies = scope.distinct
     @page = params[:page]
   end
 

--- a/app/views/web/shared/_vacancies.html.slim
+++ b/app/views/web/shared/_vacancies.html.slim
@@ -19,8 +19,10 @@
 
       .card-text.mb-2
         = truncate_markdown(vacancy.responsibilities_description.to_s, length: 200)
-        .fw-bold.mt-1
-          = vacancy.technology_list.join(', ')
+        .d-flex.fw-bold
+          - vacancy.technology_list.each do |technology|
+            .m-1
+              = filter_link(technology, { technologies_name_in: technology }, class: 'nav-item nav-link')
       / .text-end.small.mt-auto
       /   span.me-3.text-muted
       /     = distance_of_time_in_words_to_now resume.created_at


### PR DESCRIPTION
Заметил что тэги технологий ни как не используются, добавил небольшую фичу, если кликнуть на тэг технологии все вакансии отфильтруются по ней

![Снимок экрана от 2022-12-04 16-51-01](https://user-images.githubusercontent.com/48034349/205494726-6523cd29-9ebc-49f6-b86f-826dafbd10ef.png)
