### PR TITLE
#575 Hide english_fluency field in vacancies created in english version

### DIFF
--- a/app/views/web/resumes/_information.html.slim
+++ b/app/views/web/resumes/_information.html.slim
@@ -36,11 +36,12 @@
       b = han('resume', 'awards_description')
     .col-sm-9.hexlet-cv-content
       == markdown2html @resume.awards_description
-.row
-  .col-sm-3
-    b = han('resume', 'english_fluency')
-  .col-sm-9
-    = @resume.english_fluency.text
+- unless @resume.locale.eql? 'en'
+  .row
+    .col-sm-3
+      b = han('resume', 'english_fluency')
+    .col-sm-9
+      = @resume.english_fluency.text
 .row.mt-3.mb-4
   .col-sm-3
     b = han('resume', 'hexlet')

--- a/config/locales/en.activerecord.yml
+++ b/config/locales/en.activerecord.yml
@@ -103,7 +103,7 @@ en:
         contact_phone: Phone
         contact_email: Email
         contact_telegram: Telegram
-        english_fluency: Languages
+        english_fluency: English fluency
         skills_description: Skills
         awards_description: Awards, Certificates
         locale: Language


### PR DESCRIPTION
Убрал отображение english_fluency для резюме созданных в английской версии сайта. В админке видно все резюме - и en и ru, поэтому админы будут видеть это поле в ru резюме. Поменял отображение для english_fluency на English fluency. 
 В PR для #581 уберу english_fluency, если резюме создается в английской версии или редактируется английское резюме. 