### PR TITLE
#581. Add condition to validation of english_fluency in resume model.…

### DIFF
--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -15,7 +15,7 @@ class Resume < ApplicationRecord
   enumerize :relocation, in: %i[not_specified another_country another_city another_city_country not_ready], default: :not_specified
 
   validates :name, presence: true
-  validates :english_fluency, presence: true, unless: -> { locale == 'en' || (new_record? && I18n.locale == :en) }
+  validates :english_fluency, presence: true, if: -> { locale_ru? }
   validates :github_url, presence: true
   validates :summary, presence: true, length: { minimum: 200 }
   validates :skills_description, presence: true
@@ -89,5 +89,9 @@ class Resume < ApplicationRecord
 
   def self.ransackable_associations(_auth_object = nil)
     %w[directions user skills answers]
+  end
+
+  def locale_ru?
+    locale == 'ru' && !(new_record? && I18n.locale == :en)
   end
 end

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -15,7 +15,7 @@ class Resume < ApplicationRecord
   enumerize :relocation, in: %i[not_specified another_country another_city another_city_country not_ready], default: :not_specified
 
   validates :name, presence: true
-  validates :english_fluency, presence: true
+  validates :english_fluency, presence: true, unless: -> { locale == 'en' || (new_record? && I18n.locale == :en) }
   validates :github_url, presence: true
   validates :summary, presence: true, length: { minimum: 200 }
   validates :skills_description, presence: true

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -101,6 +101,6 @@ class Resume < ApplicationRecord
   end
 
   def locale_ru?
-    locale == 'ru' && !(new_record? && I18n.locale == :en)
+    locale == 'ru'
   end
 end

--- a/app/views/web/shared/_resume_form.html.slim
+++ b/app/views/web/shared/_resume_form.html.slim
@@ -10,7 +10,7 @@
     = f.input :city
   .mb-3
     = f.input :relocation, selected: resume.relocation
-  - if @resume.locale == 'ru' && !(@resume.new_record? && I18n.locale == :en)
+  - if @resume.locale_ru?
     .mb-3
       = f.input :english_fluency, required: true
   .mb-3

--- a/app/views/web/shared/_resume_form.html.slim
+++ b/app/views/web/shared/_resume_form.html.slim
@@ -10,8 +10,9 @@
     = f.input :city
   .mb-3
     = f.input :relocation, selected: resume.relocation
-  .mb-3
-    = f.input :english_fluency
+  - if @resume.locale == 'ru' && !(@resume.new_record? && I18n.locale == :en)
+    .mb-3
+      = f.input :english_fluency, required: true
   .mb-3
     = f.input :hexlet_url
   .mb-3


### PR DESCRIPTION
Добавил условие на валидацию english_fluency в модели резюме - валидация не будет выполняться если локаль резюме 'en', или если резюме новое и локаль приложения 'en'. В форме резюме условие на отображение поля ввода english_fluency - локаль резюме 'ru' и при этом резюме не новое и локаль приложения не 'en' 