### PR TITLE
Fix #518. Change @resume from Resume to ResumeForm class when it fails to update

### DIFF
--- a/app/controllers/web/account/resumes_controller.rb
+++ b/app/controllers/web/account/resumes_controller.rb
@@ -39,7 +39,7 @@ class Web::Account::ResumesController < Web::Account::ApplicationController
       f(:success)
       redirect_to account_resumes_path
     else
-      @resume = resume.becomes(Resume)
+      @resume = resume
       f(:error)
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/web/account/resumes_controller.rb
+++ b/app/controllers/web/account/resumes_controller.rb
@@ -31,15 +31,14 @@ class Web::Account::ResumesController < Web::Account::ApplicationController
   end
 
   def update
-    @resume = current_user.resumes.find params[:id]
-    resume = @resume.becomes(Web::Account::ResumeForm)
-    if resume.update(params[:resume])
+    resume = current_user.resumes.find params[:id]
+    @resume = resume.becomes(Web::Account::ResumeForm)
+    if @resume.update(params[:resume])
       change_visibility(@resume)
       OpenAiJob.perform_later(@resume.id)
       f(:success)
       redirect_to account_resumes_path
     else
-      @resume = resume
       f(:error)
       render :edit, status: :unprocessable_entity
     end


### PR DESCRIPTION
Поменял класс @resume на ResumeForm при неудачном обновлении резюме, поля измененные сохраняются. 
Но если в сохраненном резюме было образование или работа и их удалить и попытаться сохранить, при этом ввести в другое какое-нибудь поле невалидные данные, то удаленные отобразятся снова. Если исправить неверные данные и сохранить резюме, то удаленных учебы или образования там не будет.