### PR TITLE
#507. Add links to resumes vacancies empty lists

### DIFF
--- a/app/views/web/home/index.html.slim
+++ b/app/views/web/home/index.html.slim
@@ -42,3 +42,8 @@
                 = distance_of_time_in_words_to_now resume.created_at
               = link_to resume.user, user_path(resume.user)
   = paginate @resumes
+- if @resumes.empty?
+  - if params[:q].nil?
+    = render partial: 'web/shared/empty'
+  - else
+    = render partial: 'web/shared/empty_list'

--- a/app/views/web/shared/_empty.html.slim
+++ b/app/views/web/shared/_empty.html.slim
@@ -2,8 +2,8 @@ h2 = t('.empty_now_but_read_something_useful')
 
 ul
     li
-      = link_to t('.how_to_compose_resume'), t('.compose_resume_link')
+      = link_to t('.how_to_compose_resume'), t('.compose_resume_link'), target: '_blank', rel: :noopener
     li
-      = link_to t('.how_to_prepare_for_interview'), t('.prepare_for_interview_link')
+      = link_to t('.how_to_prepare_for_interview'), t('.prepare_for_interview_link'), target: '_blank', rel: :noopener
     li
-      = link_to t('.how_to_pass_interview'), t('.pass_interview_link')
+      = link_to t('.how_to_pass_interview'), t('.pass_interview_link'), target: '_blank', rel: :noopener

--- a/app/views/web/shared/_empty.html.slim
+++ b/app/views/web/shared/_empty.html.slim
@@ -1,0 +1,9 @@
+h2 = t('.empty_now_but_read_something_useful')
+
+ul
+    li
+      = link_to t('.how_to_compose_resume'), t('.compose_resume_link')
+    li
+      = link_to t('.how_to_prepare_for_interview'), t('.prepare_for_interview_link')
+    li
+      = link_to t('.how_to_pass_interview'), t('.pass_interview_link')

--- a/app/views/web/shared/_empty.html.slim
+++ b/app/views/web/shared/_empty.html.slim
@@ -2,8 +2,8 @@ h2 = t('.empty_now_but_read_something_useful')
 
 ul
     li
-      = link_to t('.how_to_compose_resume'), t('.compose_resume_link'), target: '_blank', rel: :noopener
+      = t('.compose_resume_link_html')
     li
-      = link_to t('.how_to_prepare_for_interview'), t('.prepare_for_interview_link'), target: '_blank', rel: :noopener
+      = t('.second_useful_link_html')
     li
-      = link_to t('.how_to_pass_interview'), t('.pass_interview_link'), target: '_blank', rel: :noopener
+      = t('.third_useful_link_html')

--- a/app/views/web/vacancies/index.html.slim
+++ b/app/views/web/vacancies/index.html.slim
@@ -13,3 +13,5 @@
   = auto_discovery_link_tag :rss, vacancies_url(format: :rss)
 
 = render partial: 'web/shared/vacancies', object: @vacancies
+- if @vacancies.empty?
+  = render partial: 'web/shared/empty'

--- a/config/locales/en.views.yml
+++ b/config/locales/en.views.yml
@@ -88,9 +88,9 @@ en:
         how_to_compose_resume: How to compose resume
         how_to_prepare_for_interview: How to prepare for interview
         how_to_pass_interview: How to pass interview
-        compose_resume_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-create-a-resume/'
-        prepare_for_interview_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
-        pass_interview_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-pass-the-interview/'
+        compose_resume_link: 'https://guides.hexlet.io/ru/how-to-create-a-resume/'
+        prepare_for_interview_link: 'https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
+        pass_interview_link: 'https://guides.hexlet.io/ru/how-to-pass-the-interview/'
     home:
       index:
         title: CV reviews

--- a/config/locales/en.views.yml
+++ b/config/locales/en.views.yml
@@ -83,6 +83,14 @@ en:
         title_apply: Apply recommendations
       empty_list:
         empty: Empty
+      empty:
+        empty_now_but_read_something_useful: There is nothing here yet. You can read something useful on Hexlet
+        how_to_compose_resume: How to compose resume
+        how_to_prepare_for_interview: How to prepare for interview
+        how_to_pass_interview: How to pass interview
+        compose_resume_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-create-a-resume/'
+        prepare_for_interview_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
+        pass_interview_link: 'https://translate.google.com/translate?sl=ru&tl=en&u=https://guides.hexlet.io/ru/how-to-pass-the-interview/'
     home:
       index:
         title: CV reviews

--- a/config/locales/en.views.yml
+++ b/config/locales/en.views.yml
@@ -85,12 +85,9 @@ en:
         empty: Empty
       empty:
         empty_now_but_read_something_useful: There is nothing here yet. You can read something useful on Hexlet
-        how_to_compose_resume: How to compose resume
-        how_to_prepare_for_interview: How to prepare for interview
-        how_to_pass_interview: How to pass interview
-        compose_resume_link: 'https://guides.hexlet.io/ru/how-to-create-a-resume/'
-        prepare_for_interview_link: 'https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
-        pass_interview_link: 'https://guides.hexlet.io/ru/how-to-pass-the-interview/'
+        compose_resume_link_html: <a href="https://guides.hexlet.io/ru/how-to-create-a-resume" target="_blank">How to compose resume</a>
+        second_useful_link_html: <a href="https://guides.hexlet.io/check-list-of-engineering-practices/" target="_blank">Checklist of essential engineering practices</a>
+        third_useful_link_html: <a href="https://guides.hexlet.io/learning/" target="_blank">How to learn to cope with negative thoughts</a>
     home:
       index:
         title: CV reviews

--- a/config/locales/ru.views.yml
+++ b/config/locales/ru.views.yml
@@ -83,6 +83,14 @@ ru:
         title_apply: Принять рекомендации
       empty_list:
         empty: Список пуст
+      empty:
+        empty_now_but_read_something_useful: Пока здесь ничего нет. Вы можете почитать кое-что полезное на Хекслете
+        how_to_compose_resume: Как составить резюме
+        how_to_prepare_for_interview: Как подготовиться к интервью
+        how_to_pass_interview: Как пройти собеседование
+        compose_resume_link: 'https://guides.hexlet.io/ru/how-to-create-a-resume/'
+        prepare_for_interview_link: 'https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
+        pass_interview_link: 'https://guides.hexlet.io/ru/how-to-pass-the-interview/'
     home:
       index:
         title: Резюме программиста

--- a/config/locales/ru.views.yml
+++ b/config/locales/ru.views.yml
@@ -85,12 +85,9 @@ ru:
         empty: Список пуст
       empty:
         empty_now_but_read_something_useful: Пока здесь ничего нет. Вы можете почитать кое-что полезное на Хекслете
-        how_to_compose_resume: Как составить резюме
-        how_to_prepare_for_interview: Как подготовиться к интервью
-        how_to_pass_interview: Как пройти собеседование
-        compose_resume_link: 'https://guides.hexlet.io/ru/how-to-create-a-resume/'
-        prepare_for_interview_link: 'https://guides.hexlet.io/ru/how-to-prepare-for-interview/'
-        pass_interview_link: 'https://guides.hexlet.io/ru/how-to-pass-the-interview/'
+        compose_resume_link_html: <a href="https://guides.hexlet.io/ru/how-to-create-a-resume" target="_blank">Как составить резюме</a>
+        second_useful_link_html: <a href="https://guides.hexlet.io/ru/how-to-prepare-for-interview/" target="_blank">Как подготовиться к интервью</a>
+        third_useful_link_html: <a href="https://guides.hexlet.io/ru/how-to-pass-the-interview/" target="_blank">Как проходить собеседование</a>
     home:
       index:
         title: Резюме программиста


### PR DESCRIPTION
Добавил показ ссылок на статьи Хекслета, если ещё нет вакансий или резюме. Если список пустой из-за примененных фильтров, то показывается обычное сообщение - список пуст.   