### PR TITLE
Add support of podman compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 include make-compose.mk
+include make-podman-compose.mk
 include make-services-app.mk
 
 test:

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -1,25 +1,25 @@
 compose:
-	docker compose up -d
+	docker-compose up -d
 
 compose-build:
-	docker compose build
+	docker-compose build
 
 compose-clear:
-	docker compose down -v --remove-orphans || true
+	docker-compose down -v --remove-orphans || true
 
 compose-down:
-	docker compose down || true
+	docker-compose down || true
 
 compose-install:
-	docker compose run --rm app make setup
+	docker-compose run --rm app make setup
 
 compose-logs:
-	docker compose logs -f
+	docker-compose logs -f
 
 compose-restart:
-	docker compose restart
+	docker-compose restart
 
 compose-stop:
-	docker compose stop || true
+	docker-compose stop || true
 
 compose-setup: compose-down compose-build compose-install

--- a/make-podman-compose.mk
+++ b/make-podman-compose.mk
@@ -1,0 +1,25 @@
+podman-compose:
+	podman-compose up -d
+
+podman-compose-build:
+	podman-compose build
+
+podman-compose-clear:
+	podman-compose down -v --remove-orphans || true
+
+podman-compose-down:
+	podman-compose down || true
+
+podman-compose-install:
+	podman-compose run --rm app make setup
+
+podman-compose-logs:
+	podman-compose logs -f
+
+podman-compose-restart:
+	podman-compose restart
+
+podman-compose-stop:
+	podman-compose stop || true
+
+compose-setup: podman-compose-down podman-compose-build podman-compose-install

--- a/make-podman-compose.mk
+++ b/make-podman-compose.mk
@@ -22,4 +22,4 @@ podman-compose-restart:
 podman-compose-stop:
 	podman-compose stop || true
 
-compose-setup: podman-compose-down podman-compose-build podman-compose-install
+podman-compose-setup: podman-compose-down podman-compose-build podman-compose-install


### PR DESCRIPTION
Добавил поддержку `podman-compose`

Заменил `docker compose` на явный вызов `docker-compose`, т.к podman, при эмуляции CLI от docker, не имеет команды `compose`

В итоге можно использовать оба варианта, если оба есть в системе:
* `docker-compose` 
* `podman-compose`

А если у `podman-compose` подключена эмуляция `docker-compose`,  то можно использовать стандартное поведение `make compose`