### PR TITLE
Add libssl installation to Dockerfile for PDF generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ENV NODE_VERSION 19.x
 
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash -
 
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb && \
+    dpkg -i libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
+
 RUN apt-get update \
   && apt-get install -y nodejs \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#688 

В Dockerfile добавлен шаг установки библиотеки libssl необходимой для генерации PDF