### PR TITLE
add filter and display career path on the steps page

### DIFF
--- a/app/controllers/web/admin/careers/steps_controller.rb
+++ b/app/controllers/web/admin/careers/steps_controller.rb
@@ -3,8 +3,9 @@
 class Web::Admin::Careers::StepsController < Web::Admin::Careers::ApplicationController
   def index
     query = { s: 'created_at desc' }.merge(params.permit![:q] || {})
-    @q = Career::Step.with_locale.ransack(query)
-    @steps = @q.result.page(params[:page])
+    @q = Career::Step.includes(:careers).with_locale.ransack(query)
+    @steps = @q.result.page(params[:page]).per(20)
+    @careers = Career.with_locale.all
   end
 
   def show

--- a/app/models/career/step.rb
+++ b/app/models/career/step.rb
@@ -16,4 +16,8 @@ class Career::Step < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[created_at direction locale name]
   end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[careers]
+  end
 end

--- a/app/views/web/admin/careers/steps/_filter.html.slim
+++ b/app/views/web/admin/careers/steps/_filter.html.slim
@@ -1,0 +1,7 @@
+.p-3.mb-3.bg-light
+  = search_form_for q, default_filter_form_options(url: url_for) do |f|
+    = f.input :name_cont, label: false, placeholder: han('career/step', :name)
+    = f.input :careers_slug_eq, label: false, prompt: t('career'), as: :select, collection: careers.map { |career| [career.name, career.slug] }
+    .col.d-flex.align-self-end
+      = f.button :submit, t('search'), class: 'btn-primary me-2 flex-grow-1'
+      = link_to t('reset'), url_for, class: 'btn btn-outline-primary'

--- a/app/views/web/admin/careers/steps/index.html.slim
+++ b/app/views/web/admin/careers/steps/index.html.slim
@@ -1,20 +1,21 @@
 - content_for :header do
   = t('career_steps')
 
+= render 'filter', q: @q, careers: @careers
 = render 'menu'
 
 table.table
   thead
     tr
       th = sort_link(@q, 'name')
-      th = sort_link(@q, 'locale')
+      th = sort_link(@q, 'career_name', t('.career'))
       th = sort_link(@q, 'created_at')
       th = t('.action')
   tbody
     - @steps.each do |step|
       tr
         td = step.name
-        td = step.locale
+        td = step.careers.map(&:name).join('<br/>').html_safe # rubocop:disable Rails/OutputSafety
         td = l step.created_at, format: :short
         td
           .btn-group[role='group' aria-label="#{t('action_buttons')}"]

--- a/app/views/web/admin/careers/steps/index.html.slim
+++ b/app/views/web/admin/careers/steps/index.html.slim
@@ -15,7 +15,11 @@ table.table
     - @steps.each do |step|
       tr
         td = step.name
-        td = step.careers.map(&:name).join(', ')
+        td
+          .small.mt-auto
+            - step.careers.each do |career|
+              span.badge.bg-success.text-body-tertiary = career.name
+              br
         td = l step.created_at, format: :short
         td
           .btn-group[role='group' aria-label="#{t('action_buttons')}"]

--- a/app/views/web/admin/careers/steps/index.html.slim
+++ b/app/views/web/admin/careers/steps/index.html.slim
@@ -15,7 +15,7 @@ table.table
     - @steps.each do |step|
       tr
         td = step.name
-        td = step.careers.map(&:name).join('<br/>').html_safe # rubocop:disable Rails/OutputSafety
+        td = step.careers.map(&:name).join(', ')
         td = l step.created_at, format: :short
         td
           .btn-group[role='group' aria-label="#{t('action_buttons')}"]

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -149,6 +149,7 @@ en:
           edit:
             step: 'Step: %{name}'
           index:
+            career: Career track
             edit: Edit
             show: Show
             action: Actions

--- a/config/locales/admin/ru.yml
+++ b/config/locales/admin/ru.yml
@@ -156,7 +156,11 @@ ru:
           form:
             notification: Если требуется студенту отправить уведомление
             cancel: Отменить
+          filter:
+            career: Карьерный трек
+            search: Найти
           index:
+            career: Карьерный трек
             show: Посмотреть
             edit: Редактировать
             action: Действие

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
     new_answer_comment_html: User <a href="%{user_path}">%{user}</a> left a <a href="%{answer_comment_path}">new comment</a> for your answer
     new_answer_like_html: User <a href="%{user_path}">%{user}</a> likes <a href="%{answer_path}">your answer</a>
   confirm: Are you sure?
-  career: Career path
+  career: Career track
   page: Page %{number}
   date:
     formats:

--- a/config/locales/ru.activerecord.yml
+++ b/config/locales/ru.activerecord.yml
@@ -51,6 +51,7 @@ ru:
         state/archived: В архиве
         state/finished: Завершен
       career/step:
+        created_at: Дата создания
         name: Название
         description: Описание
         locale: Язык


### PR DESCRIPTION
Хотел сделать, чтобы названия кт выводились на разных строчках, если их несколько, но ругается на html_safe, а отключить линтер в шаблоне я не смог. Сделал пока запятыми, тоже норм выглядит, с учетом того, что много кт быть не должно
<img width="1468" alt="image" src="https://github.com/Hexlet/hexlet-cv/assets/29174482/22e0b001-01f1-490e-b48a-81ea81a81bb2">

#665 
