### PR TITLE
make help links on footer corresponding to the current locale

### DIFF
--- a/app/views/layouts/shared/_footer.html.slim
+++ b/app/views/layouts/shared/_footer.html.slim
@@ -12,9 +12,10 @@ footer.bg-body-tertiary.border-top.py-4.mt-auto
       .col-sm-6.col-md-4.col-lg-auto
         .fs-4.mb-2 = t('.help')
         ul.list-unstyled
-          li.mb-3 = link_to t('.success_stories'), 'https://ru.hexlet.io/blog/categories/success', target: '_blank', rel: :noopener
-          li.mb-3 = link_to t('.test_assigments'), 'https://github.com/Hexlet/ru-test-assignments', target: '_blank', rel: :noopener
-          li = link_to t('.employment_course'), 'https://ru.hexlet.io/courses/employment', target: '_blank', rel: :noopener
+          li.mb-3 = link_to t('.success_stories'), "https://#{I18n.locale}.hexlet.io/blog/categories/success", target: '_blank', rel: :noopener
+          - locale_prefix = I18n.locale.to_s == 'en' ? '' : 'ru-'
+          li.mb-3 = link_to t('.test_assigments'), "https://github.com/Hexlet/#{locale_prefix}test-assignments", target: '_blank', rel: :noopener
+          li = link_to t('.employment_course'), "https://#{I18n.locale}.hexlet.io/courses/employment", target: '_blank', rel: :noopener
       .col-sm-6.col-md-4.col-lg-auto
         .fs-4.mb-2 = t('.additionally')
         ul.list-unstyled


### PR DESCRIPTION
The issue: https://github.com/Hexlet/hexlet-cv/issues/649

Before:
![image](https://github.com/user-attachments/assets/d93086e4-38de-4f2d-82da-bd9e2078122e)


After:
![image](https://github.com/user-attachments/assets/e6f4342f-814b-4efc-9ff4-23f99fa02d6a)
