### PR TITLE
Add user cabinet controller

### DIFF
--- a/src/main/java/io/hexlet/cv/App.java
+++ b/src/main/java/io/hexlet/cv/App.java
@@ -10,5 +10,4 @@ public class App {
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
     }
-
 }

--- a/src/main/java/io/hexlet/cv/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/cv/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                         .requestMatchers("/ru/users/sign_out", "/en/users/sign_out").permitAll()
                         .requestMatchers("/ru/users/sign_up", "/en/users/sign_up").permitAll()
                         .requestMatchers("/ru/users", "/en/users").permitAll()
-
+                        //.requestMatchers("/api/cabinet/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/io/hexlet/cv/controller/PersonalCabinetController.java
+++ b/src/main/java/io/hexlet/cv/controller/PersonalCabinetController.java
@@ -3,16 +3,15 @@ package io.hexlet.cv.controller;
 import io.hexlet.cv.dto.user.UserCabinetDto;
 import io.hexlet.cv.service.PersonalCabinetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.Map;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
-@RequestMapping("/api/cabinet")
+@RequestMapping("/personal-cabinet")
 @RequiredArgsConstructor
 public class PersonalCabinetController {
 
@@ -21,8 +20,7 @@ public class PersonalCabinetController {
     @GetMapping
     public UserCabinetDto getCabinetData(Authentication auth) {
         if (auth == null) {
-            // вернуть заглушку, если пользователь не авторизован
-            return new UserCabinetDto(null, List.of(), Map.of());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated");
         }
         return personalCabinetService.getCabinetData(auth);
     }

--- a/src/main/java/io/hexlet/cv/controller/PersonalCabinetController.java
+++ b/src/main/java/io/hexlet/cv/controller/PersonalCabinetController.java
@@ -1,0 +1,29 @@
+package io.hexlet.cv.controller;
+
+import io.hexlet.cv.dto.user.UserCabinetDto;
+import io.hexlet.cv.service.PersonalCabinetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/cabinet")
+@RequiredArgsConstructor
+public class PersonalCabinetController {
+
+    private final PersonalCabinetService personalCabinetService;
+
+    @GetMapping
+    public UserCabinetDto getCabinetData(Authentication auth) {
+        if (auth == null) {
+            // вернуть заглушку, если пользователь не авторизован
+            return new UserCabinetDto(null, List.of(), Map.of());
+        }
+        return personalCabinetService.getCabinetData(auth);
+    }
+}

--- a/src/main/java/io/hexlet/cv/dto/user/MenuItemDto.java
+++ b/src/main/java/io/hexlet/cv/dto/user/MenuItemDto.java
@@ -1,0 +1,12 @@
+package io.hexlet.cv.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MenuItemDto {
+    private String name;
+    private String url;
+    private String icon;
+}

--- a/src/main/java/io/hexlet/cv/dto/user/UserCabinetDto.java
+++ b/src/main/java/io/hexlet/cv/dto/user/UserCabinetDto.java
@@ -1,0 +1,15 @@
+package io.hexlet.cv.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+public class UserCabinetDto {
+    private UserDto user;
+    private List<MenuItemDto> menu;
+    private Map<String, Boolean> notificationSettings;
+}

--- a/src/main/java/io/hexlet/cv/dto/user/UserDto.java
+++ b/src/main/java/io/hexlet/cv/dto/user/UserDto.java
@@ -1,0 +1,13 @@
+package io.hexlet.cv.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserDto {
+    private String firstName;
+    private String lastName;
+    private String role;
+    private String avatarUrl;
+}

--- a/src/main/java/io/hexlet/cv/model/User.java
+++ b/src/main/java/io/hexlet/cv/model/User.java
@@ -46,7 +46,9 @@ public class User implements UserDetails {
     @Convert(converter = RoleTypeConverter.class)
     private RoleType role;
 
-//-----  под авторизацию -----
+    private String avatarUrl;
+
+    //-----  под авторизацию -----
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of();

--- a/src/main/java/io/hexlet/cv/service/PersonalCabinetService.java
+++ b/src/main/java/io/hexlet/cv/service/PersonalCabinetService.java
@@ -1,0 +1,44 @@
+package io.hexlet.cv.service;
+
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import io.hexlet.cv.dto.user.MenuItemDto;
+import io.hexlet.cv.dto.user.UserCabinetDto;
+import io.hexlet.cv.dto.user.UserDto;
+import io.hexlet.cv.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalCabinetService {
+    private final UserRepository userRepository;
+
+    public UserCabinetDto getCabinetData(Authentication auth) {
+        var email = auth.getName();
+        var user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        // меню пока одинаковое для всех
+        var menu = List.of(
+                new MenuItemDto("Profile", "/profile", "profile-icon"),
+                new MenuItemDto("Settings", "/settings", "settings-icon"),
+                new MenuItemDto("Notifications", "/notifications", "bell-icon")
+        );
+
+        var userDto = new UserDto(
+                user.getFirstName(),
+                user.getLastName(),
+                user.getRole().name(),
+                user.getAvatarUrl()
+        );
+
+        return new UserCabinetDto(
+                userDto,
+                menu,
+                Map.of("email_notifications", true, "push_notifications", false)
+        );
+    }
+}


### PR DESCRIPTION
Реализован функционал личного кабинета пользователя.

Сделано:
- создан контроллер PersonalCabinetController с методом getCabinetData;
- добавлены DTO для пользователя и данных кабинета (UserDTO, UserCabinetDTO);
- настроено формирование данных: имя, фамилия, роль, аватар пользователя;
- добавлен список пунктов меню и их свойств;
- реализована базовая логика формирования меню (на данном этапе одинаковая для всех ролей);
- настроен единый endpoint /personal-cabinet для получения данных кабинета

Приложение успешно запускается, эндпоинт возвращает корректный JSON-ответ.