### PR TITLE
Frontend: реализован компонент "Интервью" в лк

### DIFF
--- a/frontend/src/app/providers/i18n/locales/en.ts
+++ b/frontend/src/app/providers/i18n/locales/en.ts
@@ -144,6 +144,11 @@ export default {
           completedProgram: 'Сertificate',
         }
       },
+      interviews: {
+        title: 'Interviews',
+        typeLabel: 'Interview',
+        videoLabel: 'Video',
+      },
     },
     activityCards: {
       courses_in_process: 'Courses in Progress',
@@ -154,12 +159,13 @@ export default {
     },
     emptyPlaceholders: {
       noPurchasesTitle: 'You have no subscriptions or orders yet',
+      noInterviews: 'Interview materials have not been added yet',
     },
-
     buttonsLabels: {
       goToCatalog: 'Go to Catalog',
       open: 'Open',
       continue: 'Continue',
+      read: 'Read',
     },
     adminPage: {
       header: {

--- a/frontend/src/app/providers/i18n/locales/ru.ts
+++ b/frontend/src/app/providers/i18n/locales/ru.ts
@@ -146,10 +146,16 @@ export default {
           completedProgram: 'Сертификат',
         },
       },
+      interviews: {
+        title: 'Интервью',
+        typeLabel: 'Интервью',
+        videoLabel: 'Видео',
+      },
     },
     emptyPlaceholders: {
       noPurchasesTitle: 'У вас еще нет подписок и заказов',
       noLearningProgress: 'Начните обучение сейчас',
+      noInterviews: 'Материалы для интервью пока не добавлены',
     },
     activityCards: {
       courses_in_process: 'Курсов в работе',
@@ -161,7 +167,8 @@ export default {
     buttonsLabels: {
       goToCatalog: 'В каталог',
       open: 'Открыть',
-      continue: 'Продолжить'
+      continue: 'Продолжить',
+      read: 'Читать',
     },
     adminPage: {
       header: {

--- a/frontend/src/entities/interview/index.ts
+++ b/frontend/src/entities/interview/index.ts
@@ -1,5 +1,5 @@
 export type {
-  TKnowledgeInterview,
-  IKnowledgeInterviewsResponse,
-  IKnowledgeInterviewShowResponse,
-} from './model'
+  KnowledgeInterviewDTO,
+  KnowledgeInterviewsResponseDTO,
+  KnowledgeInterviewShowResponseDTO,
+} from './model/types'

--- a/frontend/src/entities/interview/index.ts
+++ b/frontend/src/entities/interview/index.ts
@@ -1,0 +1,5 @@
+export type {
+  TKnowledgeInterview,
+  IKnowledgeInterviewsResponse,
+  IKnowledgeInterviewShowResponse,
+} from './model'

--- a/frontend/src/entities/interview/model/index.ts
+++ b/frontend/src/entities/interview/model/index.ts
@@ -1,5 +1,0 @@
-export type {
-  TKnowledgeInterview,
-  IKnowledgeInterviewsResponse,
-  IKnowledgeInterviewShowResponse,
-} from './types'

--- a/frontend/src/entities/interview/model/index.ts
+++ b/frontend/src/entities/interview/model/index.ts
@@ -1,0 +1,5 @@
+export type {
+  TKnowledgeInterview,
+  IKnowledgeInterviewsResponse,
+  IKnowledgeInterviewShowResponse,
+} from './types'

--- a/frontend/src/entities/interview/model/types.ts
+++ b/frontend/src/entities/interview/model/types.ts
@@ -1,17 +1,17 @@
 import type { TPagination } from '@shared/types/inertiaSharedData/inertiaSharedProps'
 
-export type TKnowledgeInterview = {
+export type KnowledgeInterviewDTO = {
   id: number
   title: string
   description: string | null
   duration: string | null
 }
 
-export interface IKnowledgeInterviewsResponse {
-  interviews: TKnowledgeInterview[]
+export type KnowledgeInterviewsResponseDTO = {
+  interviews: KnowledgeInterviewDTO[]
   pagination: TPagination
 }
 
-export interface IKnowledgeInterviewShowResponse {
-  interview: TKnowledgeInterview
+export type KnowledgeInterviewShowResponseDTO = {
+  interview: KnowledgeInterviewDTO
 }

--- a/frontend/src/entities/interview/model/types.ts
+++ b/frontend/src/entities/interview/model/types.ts
@@ -1,0 +1,17 @@
+import type { TPagination } from '@shared/types/inertiaSharedData/inertiaSharedProps'
+
+export type TKnowledgeInterview = {
+  id: number
+  title: string
+  description: string | null
+  duration: string | null
+}
+
+export interface IKnowledgeInterviewsResponse {
+  interviews: TKnowledgeInterview[]
+  pagination: TPagination
+}
+
+export interface IKnowledgeInterviewShowResponse {
+  interview: TKnowledgeInterview
+}

--- a/frontend/src/features/open-interview/index.ts
+++ b/frontend/src/features/open-interview/index.ts
@@ -1,0 +1,1 @@
+export { OpenInterviewButton } from './ui/OpenInterviewButton'

--- a/frontend/src/features/open-interview/ui/OpenInterviewButton.tsx
+++ b/frontend/src/features/open-interview/ui/OpenInterviewButton.tsx
@@ -15,7 +15,7 @@ export const OpenInterviewButton: React.FC<IProps> = ({
 }) => {
   return (
     <Button
-      href={`/account/interviews/${interviewId}`}
+      href={`/account/interviews/${interviewId}/read`}
       component={Link}
       variant={variant}
       rightSection={<IconChevronRight size={14} />}

--- a/frontend/src/features/open-interview/ui/OpenInterviewButton.tsx
+++ b/frontend/src/features/open-interview/ui/OpenInterviewButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@mantine/core'
+import { IconChevronRight } from '@tabler/icons-react'
+import { Link } from '@inertiajs/react'
+
+interface IProps {
+  interviewId: number
+  children: React.ReactNode
+  variant?: string
+}
+
+export const OpenInterviewButton: React.FC<IProps> = ({
+  children,
+  interviewId,
+  variant = 'subtle',
+}) => {
+  return (
+    <Button
+      href={`/account/interviews/${interviewId}`}
+      component={Link}
+      variant={variant}
+      rightSection={<IconChevronRight size={14} />}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/frontend/src/mocks/account/index.ts
+++ b/frontend/src/mocks/account/index.ts
@@ -1,15 +1,16 @@
 import { http, delay } from 'msw'
 import { inertiaJson } from '@mocks/inertia'
-import type { MenuItem } from '@shared/types/inertiaSharedData'
+import type { TMenuItem } from '@shared/types/inertiaSharedData'
 import { purchaseHandlers } from './purchase'
 import { progressHandlers, lessonsHandlers } from '@mocks/account/progress'
+import { interviewsHandlers } from '@mocks/account/interviews'
 
-export const menu: MenuItem[] = [
+export const menu: TMenuItem[] = [
   { label: 'Мое обучение', link: '/account/my-progress' },
   { label: 'Покупки и подписки', link: '/account/purchase' },
   { label: 'Вебинары', link: '/account/webinars' },
   { label: 'База знаний' },
-  { label: 'Интервью' },
+  { label: 'Интервью', link: '/account/interviews' },
   { label: 'Грейдирование' },
   { label: 'Программы обучения' },
 ]
@@ -62,4 +63,5 @@ export const handlers = [
   ...purchaseHandlers,
   ...progressHandlers,
   ...lessonsHandlers,
+  ...interviewsHandlers,
 ]

--- a/frontend/src/mocks/account/interviews/index.ts
+++ b/frontend/src/mocks/account/interviews/index.ts
@@ -1,0 +1,1 @@
+export { interviewsHandlers } from './interviewsHandlers'

--- a/frontend/src/mocks/account/interviews/interviewsHandlers.ts
+++ b/frontend/src/mocks/account/interviews/interviewsHandlers.ts
@@ -53,7 +53,7 @@ export const interviewsHandlers = [
       url: url.pathname + url.search,
     })
   }),
-  http.get('/account/interviews/:id', async ({ params }) => {
+  http.get('/account/interviews/:id/read', async ({ params, request }) => {
     await delay()
 
     const interview = interviews.find(({ id }) => id === parseInt(params.id as string, 10))
@@ -71,7 +71,7 @@ export const interviewsHandlers = [
         activeMainSection: 'account',
         activeSubSection: 'interviews',
       },
-      url: `/account/interviews/${interview.id}`,
+      url: new URL(request.url).pathname,
     })
   }),
 ]

--- a/frontend/src/mocks/account/interviews/interviewsHandlers.ts
+++ b/frontend/src/mocks/account/interviews/interviewsHandlers.ts
@@ -1,0 +1,77 @@
+import { http, delay } from 'msw'
+import { inertiaJson } from '@mocks/inertia'
+import { menu, activityCards } from '../index'
+
+const interviews = [
+  {
+    id: 1,
+    title: 'Как отвечать на вопросы про опыт',
+    description: 'Разбор типовых вопросов о проектах, ролях и зонах ответственности на техническом интервью.',
+    duration: '12 мин',
+  },
+  {
+    id: 2,
+    title: 'Frontend-интервью: JavaScript и асинхронность',
+    description: 'Подборка вопросов по event loop, promises и сетевому взаимодействию с краткими пояснениями.',
+    duration: '18 мин',
+  },
+  {
+    id: 3,
+    title: 'Интервью: SQL для аналитика',
+    description: 'JOIN, оконные функции и типовые SQL-вопросы на собеседовании.',
+    duration: '9 мин',
+  },
+]
+
+export const interviewsHandlers = [
+  http.get('/account/interviews', async ({ request }) => {
+    await delay()
+
+    const url = new URL(request.url)
+    const page = parseInt(url.searchParams.get('page') || '0', 10)
+    const pageSize = 9
+
+    const start = page * pageSize
+    const end = start + pageSize
+    const pagedInterviews = interviews.slice(start, end)
+
+    return inertiaJson({
+      component: 'Account/Interview/Index',
+      props: {
+        menu,
+        activityCards,
+        interviews: pagedInterviews,
+        pagination: {
+          currentPage: page,
+          totalPages: Math.ceil(interviews.length / pageSize),
+          totalElements: interviews.length,
+          pageSize,
+        },
+        activeMainSection: 'account',
+        activeSubSection: 'interviews',
+      },
+      url: url.pathname + url.search,
+    })
+  }),
+  http.get('/account/interviews/:id', async ({ params }) => {
+    await delay()
+
+    const interview = interviews.find(({ id }) => id === parseInt(params.id as string, 10))
+
+    if (!interview) {
+      return new Response(null, { status: 404 })
+    }
+
+    return inertiaJson({
+      component: 'Account/Interview/Read',
+      props: {
+        menu,
+        activityCards,
+        interview,
+        activeMainSection: 'account',
+        activeSubSection: 'interviews',
+      },
+      url: `/account/interviews/${interview.id}`,
+    })
+  }),
+]

--- a/frontend/src/pages/Account/Interview/Index.tsx
+++ b/frontend/src/pages/Account/Interview/Index.tsx
@@ -2,14 +2,14 @@ import { Container } from '@mantine/core'
 import { IconMessage, IconSearchOff } from '@tabler/icons-react'
 import { useTranslation } from 'react-i18next'
 import type { InertiaPage } from '@shared/types/inertia'
-import type { IKnowledgeInterviewsResponse } from '@entities/interview'
+import type { KnowledgeInterviewsResponseDTO } from '@entities/interview'
 import { AppLayout } from '@pages/Account/components/AppLayout'
 import { PageHeader } from '@widgets/page-header'
 import { EntityGrid } from '@widgets/entity-grid'
 import { InterviewCard } from '@widgets/interview-card'
 import { OpenInterviewButton } from '@features/open-interview'
 
-const InterviewsPage: InertiaPage<IKnowledgeInterviewsResponse> = ({
+const InterviewsPage: InertiaPage<KnowledgeInterviewsResponseDTO> = ({
   interviews,
   pagination,
 }) => {
@@ -34,7 +34,6 @@ const InterviewsPage: InertiaPage<IKnowledgeInterviewsResponse> = ({
         }}
         renderItem={interview => (
           <InterviewCard
-            key={interview.id}
             interview={interview}
             actionButton={(
               <OpenInterviewButton interviewId={interview.id}>

--- a/frontend/src/pages/Account/Interview/Index.tsx
+++ b/frontend/src/pages/Account/Interview/Index.tsx
@@ -1,0 +1,53 @@
+import { Container } from '@mantine/core'
+import { IconMessage, IconSearchOff } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+import type { InertiaPage } from '@shared/types/inertia'
+import type { IKnowledgeInterviewsResponse } from '@entities/interview'
+import { AppLayout } from '@pages/Account/components/AppLayout'
+import { PageHeader } from '@widgets/page-header'
+import { EntityGrid } from '@widgets/entity-grid'
+import { InterviewCard } from '@widgets/interview-card'
+import { OpenInterviewButton } from '@features/open-interview'
+
+const InterviewsPage: InertiaPage<IKnowledgeInterviewsResponse> = ({
+  interviews,
+  pagination,
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <Container fluid>
+      <PageHeader
+        icon={<IconMessage />}
+        title={t('accountPage.interviews.title')}
+      />
+
+      <EntityGrid
+        data={interviews}
+        pagination={pagination}
+        baseUrl="/account/interviews"
+        emptyConfig={{
+          title: t('emptyPlaceholders.noInterviews'),
+          icon: IconSearchOff,
+          buttonLink: '/account/interviews',
+          buttonLabel: t('buttonsLabels.read'),
+        }}
+        renderItem={interview => (
+          <InterviewCard
+            key={interview.id}
+            interview={interview}
+            actionButton={(
+              <OpenInterviewButton interviewId={interview.id}>
+                {t('buttonsLabels.read')}
+              </OpenInterviewButton>
+            )}
+          />
+        )}
+      />
+    </Container>
+  )
+}
+
+InterviewsPage.layout = page => <AppLayout>{page}</AppLayout>
+
+export default InterviewsPage

--- a/frontend/src/pages/Account/Interview/Read.tsx
+++ b/frontend/src/pages/Account/Interview/Read.tsx
@@ -1,9 +1,9 @@
 import { Stack, Text, Title } from '@mantine/core'
 import type { InertiaPage } from '@shared/types/inertia'
-import type { IKnowledgeInterviewShowResponse } from '@entities/interview'
+import type { KnowledgeInterviewShowResponseDTO } from '@entities/interview'
 import { AppLayout } from '@pages/Account/components/AppLayout'
 
-const InterviewReadPage: InertiaPage<IKnowledgeInterviewShowResponse> = ({
+const InterviewReadPage: InertiaPage<KnowledgeInterviewShowResponseDTO> = ({
   interview,
 }) => {
   return (

--- a/frontend/src/pages/Account/Interview/Read.tsx
+++ b/frontend/src/pages/Account/Interview/Read.tsx
@@ -1,0 +1,19 @@
+import { Stack, Text, Title } from '@mantine/core'
+import type { InertiaPage } from '@shared/types/inertia'
+import type { IKnowledgeInterviewShowResponse } from '@entities/interview'
+import { AppLayout } from '@pages/Account/components/AppLayout'
+
+const InterviewReadPage: InertiaPage<IKnowledgeInterviewShowResponse> = ({
+  interview,
+}) => {
+  return (
+    <Stack>
+      <Title order={2}>{interview.title}</Title>
+      {interview.description && <Text>{interview.description}</Text>}
+    </Stack>
+  )
+}
+
+InterviewReadPage.layout = page => <AppLayout>{page}</AppLayout>
+
+export default InterviewReadPage

--- a/frontend/src/pages/Account/components/Navbar.tsx
+++ b/frontend/src/pages/Account/components/Navbar.tsx
@@ -9,11 +9,13 @@ export const Navbar: React.FC = React.memo(() => {
   const { props: pageProps, url } = usePage()
   const { menu } = pageProps
   const { opened, toggle: navbarToggle } = useNavbar()
+  const normalizedUrl = normalizePathname(url)
 
   const ativeMenu =
-    menu?.find(
-      ({ link }) => normalizePathname(link) === normalizePathname(url),
-    ) || menu[0]
+    menu?.find(({ link }) => {
+      const normalizedLink = normalizePathname(link)
+      return normalizedLink && normalizedUrl?.startsWith(normalizedLink)
+    }) || menu[0]
 
   const links =
     menu?.map((item) => (

--- a/frontend/src/widgets/interview-card/index.ts
+++ b/frontend/src/widgets/interview-card/index.ts
@@ -1,0 +1,1 @@
+export { InterviewCard } from './ui/InterviewCard'

--- a/frontend/src/widgets/interview-card/ui/InterviewCard.tsx
+++ b/frontend/src/widgets/interview-card/ui/InterviewCard.tsx
@@ -1,18 +1,20 @@
 import {
-  Card,
+  Flex,
   Group,
   Stack,
   Text,
 } from '@mantine/core'
+import type { FC, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { TKnowledgeInterview } from '@entities/interview'
+import { DsCard } from '@shared/uikit/DsCard/DsCard'
+import type { KnowledgeInterviewDTO } from '@entities/interview'
 
 interface InterviewCardProps {
-  interview: TKnowledgeInterview
-  actionButton: React.ReactNode
+  interview: KnowledgeInterviewDTO
+  actionButton: ReactNode
 }
 
-export const InterviewCard: React.FC<InterviewCardProps> = ({
+export const InterviewCard: FC<InterviewCardProps> = ({
   interview,
   actionButton,
 }) => {
@@ -24,29 +26,29 @@ export const InterviewCard: React.FC<InterviewCardProps> = ({
     : videoLabel
 
   return (
-    <Card
+    <DsCard
       shadow="sm"
       padding="md"
       radius="md"
       withBorder
-      flex={1}
-      h={173}
-      display="flex"
-      style={{ flexDirection: 'column' }}
     >
-      <Stack gap="xs" h="100%">
-        <Stack gap={2} style={{ minHeight: 78 }}>
-          <Text fw={700} size="lg" lineClamp={2} style={{ lineHeight: 1.25 }}>
-            {typeLabel} · {interview.title}
-          </Text>
-          <Text c="dimmed" size="sm">
-            {metaLine}
-          </Text>
-        </Stack>
-        <Group mt="auto" justify="flex-start">
-          {actionButton}
-        </Group>
-      </Stack>
-    </Card>
+      <DsCard.Content>
+        <Flex direction="column" gap="xs">
+          <Stack gap={2}>
+            <Text fw={700} size="lg" lineClamp={2} lh={1.25}>
+              {typeLabel}
+              {' · '}
+              {interview.title}
+            </Text>
+            <Text c="dimmed" size="sm">
+              {metaLine}
+            </Text>
+          </Stack>
+          <Group justify="flex-start" mt="xs">
+            {actionButton}
+          </Group>
+        </Flex>
+      </DsCard.Content>
+    </DsCard>
   )
 }

--- a/frontend/src/widgets/interview-card/ui/InterviewCard.tsx
+++ b/frontend/src/widgets/interview-card/ui/InterviewCard.tsx
@@ -1,0 +1,52 @@
+import {
+  Card,
+  Group,
+  Stack,
+  Text,
+} from '@mantine/core'
+import { useTranslation } from 'react-i18next'
+import type { TKnowledgeInterview } from '@entities/interview'
+
+interface InterviewCardProps {
+  interview: TKnowledgeInterview
+  actionButton: React.ReactNode
+}
+
+export const InterviewCard: React.FC<InterviewCardProps> = ({
+  interview,
+  actionButton,
+}) => {
+  const { t } = useTranslation()
+  const typeLabel = t('accountPage.interviews.typeLabel')
+  const videoLabel = t('accountPage.interviews.videoLabel')
+  const metaLine = interview.duration
+    ? `${videoLabel} · ${interview.duration}`
+    : videoLabel
+
+  return (
+    <Card
+      shadow="sm"
+      padding="md"
+      radius="md"
+      withBorder
+      flex={1}
+      h={173}
+      display="flex"
+      style={{ flexDirection: 'column' }}
+    >
+      <Stack gap="xs" h="100%">
+        <Stack gap={2} style={{ minHeight: 78 }}>
+          <Text fw={700} size="lg" lineClamp={2} style={{ lineHeight: 1.25 }}>
+            {typeLabel} · {interview.title}
+          </Text>
+          <Text c="dimmed" size="sm">
+            {metaLine}
+          </Text>
+        </Stack>
+        <Group mt="auto" justify="flex-start">
+          {actionButton}
+        </Group>
+      </Stack>
+    </Card>
+  )
+}


### PR DESCRIPTION
Задача: #1018 

Что сделано:
- Добавлена страница списка интервью в ЛК (`/account/interviews`)
- Добавлена страница материала интервью (`/account/interviews/:id`)
- Реализованы карточки интервью и кнопка «Читать»
- Подключен рендер через `EntityGrid` с пагинацией
- Добавлены/обновлены MSW-обработчики для интервью

Технические изменения:
- Навигация в левом меню: добавлен рабочий пункт `Интервью`
- В `Navbar` исправлено определение активного пункта для вложенных URL (`startsWith`)
- Моки интервью вынесены в отдельный модуль `mocks/account/interviews`

Итог:
<img width="1681" height="987" alt="Screenshot 2026-03-10 at 18 47 49" src="https://github.com/user-attachments/assets/b646add2-c240-4af6-9fc3-28f9abb33ebe" />
