### PR TITLE
[feat-1027]: реализован компонент "Вебинары" в лк

### DIFF
--- a/frontend/src/app/providers/i18n/locales/en.ts
+++ b/frontend/src/app/providers/i18n/locales/en.ts
@@ -207,17 +207,6 @@ export default {
           'Helps with resumes, applications, correspondence with recruiters, and interview preparation.',
       },
     },
-    header: {
-      auth: {
-        account: 'Account',
-        admin: 'Admin',
-        signOut: 'Sign out',
-        tryFreeLine1: 'Try',
-        tryFreeLine2: 'for free',
-        signIn: 'Sign in',
-        signUp: 'Sign up',
-      },
-    },
     accountPage: {
       purchases: {
         title: 'My purchases and subscriptions',
@@ -253,17 +242,23 @@ export default {
           completedProgram: 'Сertificate',
         },
       },
-      studyPrograms: {
-        title: 'Study programs',
-        noPrograms: 'You have no any active study programs yet',
-        incorrectData: 'Study programs loading error',
-      },
       notifications: {
         title: 'Notifications',
         today: 'today',
         yesterday: 'yesterday',
         daysAgo: 'long ago',
         noNotifications: 'No notifications',
+      },
+      webinars: {
+        title: 'Webinars',
+        registration: 'Register',
+        addToCalendar: 'Add to Calendar',
+        shedule: 'Schedule',
+        noWebinars: 'No webinars scheduled yet',
+        location: {
+          online: 'Online',
+          offline: 'Offline',
+        },
       },
     },
     activityCards: {

--- a/frontend/src/app/providers/i18n/locales/ru.ts
+++ b/frontend/src/app/providers/i18n/locales/ru.ts
@@ -267,6 +267,17 @@ export default {
         daysAgo: 'давно',
         noNotifications: 'Уведомлений нет',
       },
+      webinars: {
+        title: 'Вебинары',
+        registration: 'Зарегистрироваться',
+        addToCalendar: 'Добавить в календарь',
+        shedule: 'Расписание',
+        noWebinars: 'Пока нет запланированных вебинаров',
+        location: {
+          online: 'Онлайн',
+          offline: 'Офлайн',
+        },
+      },
     },
     emptyPlaceholders: {
       noPurchasesTitle: 'У вас еще нет подписок и заказов',

--- a/frontend/src/entities/learning-progress/index.ts
+++ b/frontend/src/entities/learning-progress/index.ts
@@ -1,2 +1,7 @@
-export type { TProgress } from './model/'
-
+export type {
+  LearningProgressDTO,
+  IProgressResponse,
+  BadgeStatus,
+} from './model/types'
+export { getBadgeStatus } from './lib/getBadgeStatus'
+export { getBadgeConfig } from './lib/getBadgeConfig'

--- a/frontend/src/entities/learning-progress/index.ts
+++ b/frontend/src/entities/learning-progress/index.ts
@@ -1,1 +1,2 @@
 export type { TProgress } from './model/'
+

--- a/frontend/src/entities/learning-progress/lib/getBadgeConfig.ts
+++ b/frontend/src/entities/learning-progress/lib/getBadgeConfig.ts
@@ -1,9 +1,12 @@
 import type { ReactNode } from 'react'
 import type { TFunction } from 'i18next'
 import type { MantineColor } from '@mantine/core'
-import type { BadgeStatus } from '@entities/learning-progress/model/getBadgeStatus'
+import type { BadgeStatus } from '../index'
 
-export const getBadgeConfig = (status: BadgeStatus, t: TFunction): { label: ReactNode, color: MantineColor } | null => {
+export const getBadgeConfig = (
+  status: BadgeStatus,
+  t: TFunction,
+): { label: ReactNode; color: MantineColor } | null => {
   if (status === 'completed') {
     return {
       label: t('accountPage.progress.programBadge.completedProgram'),

--- a/frontend/src/entities/learning-progress/lib/getBadgeConfig.ts
+++ b/frontend/src/entities/learning-progress/lib/getBadgeConfig.ts
@@ -3,10 +3,7 @@ import type { TFunction } from 'i18next'
 import type { MantineColor } from '@mantine/core'
 import type { BadgeStatus } from '@entities/learning-progress/model/getBadgeStatus'
 
-export const getBadgeConfig = (
-  status: BadgeStatus,
-  t: TFunction,
-): { label: ReactNode; color: MantineColor } | null => {
+export const getBadgeConfig = (status: BadgeStatus, t: TFunction): { label: ReactNode, color: MantineColor } | null => {
   if (status === 'completed') {
     return {
       label: t('accountPage.progress.programBadge.completedProgram'),

--- a/frontend/src/entities/learning-progress/lib/getBadgeStatus.ts
+++ b/frontend/src/entities/learning-progress/lib/getBadgeStatus.ts
@@ -1,0 +1,9 @@
+import type { BadgeStatus } from '../index'
+export const getBadgeStatus = (
+  isCompleted: boolean,
+  completedLessons: number,
+): BadgeStatus => {
+  if (isCompleted) return 'completed'
+  if (completedLessons === 0) return 'new'
+  return null
+}

--- a/frontend/src/entities/learning-progress/model/getBadgeStatus.ts
+++ b/frontend/src/entities/learning-progress/model/getBadgeStatus.ts
@@ -1,7 +1,0 @@
-export type BadgeStatus = 'completed' | 'new' | null
-
-export const getBadgeStatus = (isCompleted: boolean, completedLessons: number): BadgeStatus => {
-  if (isCompleted) return 'completed'
-  if (completedLessons === 0) return 'new'
-  return null
-}

--- a/frontend/src/entities/learning-progress/model/getBadgeStatus.ts
+++ b/frontend/src/entities/learning-progress/model/getBadgeStatus.ts
@@ -1,9 +1,6 @@
 export type BadgeStatus = 'completed' | 'new' | null
 
-export const getBadgeStatus = (
-  isCompleted: boolean,
-  completedLessons: number,
-): BadgeStatus => {
+export const getBadgeStatus = (isCompleted: boolean, completedLessons: number): BadgeStatus => {
   if (isCompleted) return 'completed'
   if (completedLessons === 0) return 'new'
   return null

--- a/frontend/src/entities/learning-progress/model/index.ts
+++ b/frontend/src/entities/learning-progress/model/index.ts
@@ -1,1 +1,0 @@
-export type { TProgress, IProgressResponse } from './types'

--- a/frontend/src/entities/learning-progress/model/types.tsx
+++ b/frontend/src/entities/learning-progress/model/types.tsx
@@ -1,6 +1,8 @@
 import type { TPagination } from '@shared/types'
 
-export type TProgress = {
+export type BadgeStatus = 'completed' | 'new' | null
+
+export type LearningProgressDTO = {
   id: number
   programTitle: string
   lastLessonTitle: string
@@ -13,6 +15,6 @@ export type TProgress = {
 }
 
 export interface IProgressResponse {
-  progress: TProgress[]
+  progress: LearningProgressDTO[]
   pagination: TPagination
 }

--- a/frontend/src/entities/webinar/index.ts
+++ b/frontend/src/entities/webinar/index.ts
@@ -1,0 +1,1 @@
+export type { WebinarDTO, WebinarsResponseDTO } from './model/types'

--- a/frontend/src/entities/webinar/model/types.ts
+++ b/frontend/src/entities/webinar/model/types.ts
@@ -1,0 +1,15 @@
+import type { TPagination } from '@shared/types'
+
+export type WebinarDTO = {
+  id: number
+  title: string
+  date: string
+  time: string
+  isOnline: boolean
+  isPublic: boolean
+}
+
+export interface WebinarsResponseDTO {
+  webinars: WebinarDTO[]
+  pagination: TPagination
+}

--- a/frontend/src/features/add-webinar-to-calendare/index.ts
+++ b/frontend/src/features/add-webinar-to-calendare/index.ts
@@ -1,0 +1,1 @@
+export { AddWebinarToCalendareButton } from './ui/AddWebinarToCalendareButton'

--- a/frontend/src/features/add-webinar-to-calendare/ui/AddWebinarToCalendareButton.tsx
+++ b/frontend/src/features/add-webinar-to-calendare/ui/AddWebinarToCalendareButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@mantine/core'
+import { Link } from '@inertiajs/react'
+
+interface IProps {
+  itemId: number
+  children: React.ReactNode
+  variant?: string
+}
+
+/**
+ * Кнопка добавления вебинара в календарь.
+ * Рендерит Inertia Link через Mantine Button по URL с `itemId`.
+ */
+export const AddWebinarToCalendareButton: React.FC<IProps> = ({
+  itemId,
+  children,
+  variant = 'subtle',
+}) => {
+  // TODO: заменить на реальную ссылку
+  const href = `/calendare/${itemId}/register`
+  return (
+    <Button href={href} component={Link} variant={variant}>
+      {children}
+    </Button>
+  )
+}

--- a/frontend/src/features/open-review-form/index.ts
+++ b/frontend/src/features/open-review-form/index.ts
@@ -1,0 +1,1 @@
+export { OpenReviewForm } from '@features/open-review-form/ui/OpenReviewForm'

--- a/frontend/src/features/open-review-form/ui/OpenReviewForm.tsx
+++ b/frontend/src/features/open-review-form/ui/OpenReviewForm.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@mantine/core'
+import { IconPlus } from '@tabler/icons-react'
+import { Link } from '@inertiajs/react'
+
+interface IProps {
+  children: React.ReactNode
+  variant?: string
+}
+
+/**
+ * Кнопка открытия формы отзыва.
+ * Рендерит ссылку на `/sсhedule` через Mantine Button (Inertia Link).
+ */
+export const OpenReviewForm: React.FC<IProps> = ({
+  children,
+  variant = 'subtle',
+}) => {
+  return (
+    <Button
+      href={`/sсhedule`}
+      component={Link}
+      variant={variant}
+      leftSection={<IconPlus size={14} />}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/frontend/src/features/open-schedule/index.ts
+++ b/frontend/src/features/open-schedule/index.ts
@@ -1,0 +1,1 @@
+export { OpenScheduleButton } from './ui/OpenScheduleButton'

--- a/frontend/src/features/open-schedule/ui/OpenScheduleButton.tsx
+++ b/frontend/src/features/open-schedule/ui/OpenScheduleButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@mantine/core'
+import { IconPlus } from '@tabler/icons-react'
+import { Link } from '@inertiajs/react'
+
+interface IProps {
+  children: React.ReactNode
+  variant?: string
+}
+
+/**
+ * Кнопка перехода к общему расписанию вебинаров.
+ * Рендерит ссылку на `/sсhedule` через Mantine Button.
+ */
+export const OpenScheduleButton: React.FC<IProps> = ({
+  children,
+  variant = 'subtle',
+}) => {
+  return (
+    <Button
+      href={`/shedule`}
+      component={Link}
+      variant={variant}
+      leftSection={<IconPlus size={14} />}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/frontend/src/features/register-webinar/index.ts
+++ b/frontend/src/features/register-webinar/index.ts
@@ -1,0 +1,1 @@
+export { RegisterWebinarButton } from './ui/RegisterWebinarButton'

--- a/frontend/src/features/register-webinar/ui/RegisterWebinarButton.tsx
+++ b/frontend/src/features/register-webinar/ui/RegisterWebinarButton.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@mantine/core'
+import { Link } from '@inertiajs/react'
+
+interface IProps {
+  webinarId: number
+  children: React.ReactNode
+  variant?: string
+}
+export const RegisterWebinarButton: React.FC<IProps> = ({
+  webinarId,
+  children,
+  variant = 'subtle',
+}) => {
+  // TODO: заменить на реальную ссылку
+  const href = `/webinar/${webinarId}/register`
+  return (
+    <Button href={href} component={Link} variant={variant}>
+      {children}
+    </Button>
+  )
+}

--- a/frontend/src/features/remind-webinar/index.ts
+++ b/frontend/src/features/remind-webinar/index.ts
@@ -1,0 +1,1 @@
+export { RemindWebinarButton } from './ui/RemindWebinarButton'

--- a/frontend/src/features/remind-webinar/ui/RemindWebinarButton.tsx
+++ b/frontend/src/features/remind-webinar/ui/RemindWebinarButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@mantine/core'
+import { Link } from '@inertiajs/react'
+import { IconBellPlus } from '@tabler/icons-react'
+
+interface IProps {
+  itemId: number
+
+  variant?: string
+}
+export const RemindWebinarButton: React.FC<IProps> = ({
+  itemId,
+  variant = 'subtle',
+}) => {
+  return (
+    <Button
+      p={0}
+      // TODO: заменить на реальную ссылку
+      href={`/remind/${itemId}/register`}
+      component={Link}
+      variant={variant}
+    >
+      <IconBellPlus size={24} />
+    </Button>
+  )
+}

--- a/frontend/src/mocks/account/index.ts
+++ b/frontend/src/mocks/account/index.ts
@@ -5,6 +5,7 @@ import { notificationsHandlers } from '@mocks/account/notifications/index'
 import { defineGet } from '@mocks/msw/define'
 import type { MswCtx } from '@mocks/msw/createCtx'
 import { programsHandlers } from '@mocks/account/programs/index'
+import { webinarsHandlers } from '@mocks/account/webinars'
 
 export const menu: TMenuItem[] = [
   { label: 'Мое обучение', link: '/account/my-progress' },
@@ -57,10 +58,6 @@ const routes = [
     component: 'Account/Purchase/Index',
     url: '/account',
   },
-  {
-    component: 'Account/Webinars/Index',
-    url: '/account/webinars',
-  },
 ] as const
 
 export const handlers = [
@@ -70,4 +67,5 @@ export const handlers = [
   ...lessonsHandlers,
   ...programsHandlers,
   ...notificationsHandlers,
+  ...webinarsHandlers,
 ]

--- a/frontend/src/mocks/account/progress/progressHandlers.ts
+++ b/frontend/src/mocks/account/progress/progressHandlers.ts
@@ -1,5 +1,6 @@
-import { defineGet } from '@mocks/msw/define'
-import { menu, activityCards } from '@mocks/account/index'
+import { http, delay } from 'msw'
+import { inertiaJson } from '@mocks/inertia'
+import { menu, activityCards } from '@mocks/account'
 
 const progress = [
   {
@@ -148,22 +149,21 @@ const progress = [
 ]
 
 export const progressHandlers = [
-  defineGet('*/account/my-progress', (ctx, request) => {
+  http.get('/account/my-progress', async ({ request }) => {
+    await delay()
+
     // 1. Извлекаем номер страницы из URL (Inertia пришлет ?page=0, ?page=1 и т.д.)
     const url = new URL(request.url)
-    const page = parseInt(url.searchParams.get('page') || '0', 9)
+    const page = parseInt(url.searchParams.get('page') || '0', 10)
     const pageSize = 9
 
     const start = page * pageSize
     const end = start + pageSize
     const pagedProgress = progress.slice(start, end)
 
-    return ctx.inertiaPage(
-      'Account/Learning/MyProgress/Index',
-      {
-        flash: {},
-        errors: {},
-        auth: { user: ctx.user },
+    return inertiaJson({
+      component: 'Account/Learning/MyProgress/Index',
+      props: {
         menu,
         activityCards,
         progress: pagedProgress,
@@ -176,7 +176,7 @@ export const progressHandlers = [
         activeMainSection: 'account',
         activeSubSection: 'my-progress',
       },
-      200
-    )
+      url: '/account/my-progress',
+    })
   }),
 ]

--- a/frontend/src/mocks/account/webinars/index.ts
+++ b/frontend/src/mocks/account/webinars/index.ts
@@ -1,0 +1,55 @@
+import { http, delay } from 'msw'
+import { inertiaJson } from '@mocks/inertia'
+import { menu, activityCards } from '@mocks/account'
+
+const webinars = [
+  {
+    id: 1,
+    title: 'Название вебинара',
+    date: '20.12.2024',
+    time: '10:00',
+    isOnline: true,
+    isPublic: true,
+  },
+  {
+    id: 2,
+    title: 'Java Core',
+    date: '21.12.2024',
+    time: '15:00',
+    isOnline: false,
+    isPublic: false,
+  },
+]
+
+export const webinarsHandlers = [
+  http.get('/account/webinars', async ({ request }) => {
+    await delay()
+
+    // 1. Извлекаем номер страницы из URL (Inertia пришлет ?page=0, ?page=1 и т.д.)
+    const url = new URL(request.url)
+    const page = Number.parseInt(url.searchParams.get('page') || '0', 10)
+    const pageSize = 9
+
+    const start = page * pageSize
+    const end = start + pageSize
+    const pagedWebinars = webinars.slice(start, end)
+
+    return inertiaJson({
+      component: 'Account/Webinars/Index',
+      props: {
+        menu,
+        activityCards,
+        webinars: pagedWebinars,
+        pagination: {
+          currentPage: page, // Текущая страница из запроса
+          totalPages: Math.ceil(webinars.length / pageSize),
+          totalElements: webinars.length,
+          pageSize: pageSize,
+        },
+        activeMainSection: 'account',
+        activeSubSection: 'webinars',
+      },
+      url: '/account/webinars',
+    })
+  }),
+]

--- a/frontend/src/pages/Account/Webinars/Index.tsx
+++ b/frontend/src/pages/Account/Webinars/Index.tsx
@@ -1,14 +1,50 @@
 import type { InertiaPage } from '@shared/types/inertia'
+import type { WebinarsResponseDTO } from '@entities/webinar/'
+import { Container } from '@mantine/core'
+import { useTranslation } from 'react-i18next'
+import { IconVideo, IconShoppingCart } from '@tabler/icons-react'
+import { PageHeader } from '@widgets/page-header'
+import { EntityGrid } from '@widgets/entity-grid'
 import { AppLayout } from '../components/AppLayout'
+import { AccountWebinarCard } from '@widgets/account-webinar-card'
+import { OpenScheduleButton } from '@features/open-schedule'
 
-const Webinars: InertiaPage = () => {
-  return 'Webinars'
+/**
+ * Страница «Вебинары» в личном кабинете (Inertia).
+ * Рендерит заголовок, кнопку к расписанию и список вебинаров с пагинацией.
+ */
+const Webinars: InertiaPage<WebinarsResponseDTO> = ({
+  webinars,
+  pagination,
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Container fluid>
+      <PageHeader
+        icon={<IconVideo />}
+        title={t('accountPage.webinars.title')}
+        actionButton={
+          <OpenScheduleButton variant="outline">
+            {t('accountPage.webinars.shedule')}
+          </OpenScheduleButton>
+        }
+      />
+      <EntityGrid
+        data={webinars}
+        pagination={pagination}
+        baseUrl="/account/webinars"
+        emptyConfig={{
+          title: t('accountPage.webinars.noWebinars'),
+          icon: IconShoppingCart,
+          buttonLink: '#',
+          buttonLabel: t('buttonsLabels.goToCatalog'),
+        }}
+        // Рендер конкретного элемента
+        renderItem={(webinar) => <AccountWebinarCard webinar={webinar} />}
+      />
+    </Container>
+  )
 }
-
-Webinars.layout = page => (
-  <AppLayout>
-    {page}
-  </AppLayout>
-)
+Webinars.layout = (page) => <AppLayout>{page}</AppLayout>
 
 export default Webinars

--- a/frontend/src/shared/ui/EmptyPlaceholder/EmptyPlaceholder.tsx
+++ b/frontend/src/shared/ui/EmptyPlaceholder/EmptyPlaceholder.tsx
@@ -11,7 +11,9 @@ export const EmptyPlaceholder: React.FC<EmptyPlaceholderProps> = (props) => {
   const { buttonLink, buttonLabel, title, icon: Icon } = props
   return (
     <Stack align="center">
-      <Title order={2}>{title}</Title>
+      <Title order={2} ta="center">
+        {title}
+      </Title>
 
       {Icon && (
         <Text c="dimmed">

--- a/frontend/src/widgets/account-webinar-card/index.ts
+++ b/frontend/src/widgets/account-webinar-card/index.ts
@@ -1,0 +1,2 @@
+export { AccountWebinarCard } from './ui/AccountWebinarCard'
+export type { WebinarsCardDto } from './types'

--- a/frontend/src/widgets/account-webinar-card/types.ts
+++ b/frontend/src/widgets/account-webinar-card/types.ts
@@ -1,0 +1,4 @@
+export type WebinarsCardDto = {
+  description: string
+  title: string
+}

--- a/frontend/src/widgets/account-webinar-card/ui/AccountWebinarCard.tsx
+++ b/frontend/src/widgets/account-webinar-card/ui/AccountWebinarCard.tsx
@@ -1,0 +1,59 @@
+import { Text, Group, Stack } from '@mantine/core'
+import type { WebinarDTO } from '@entities/webinar/'
+import { useTranslation } from 'react-i18next'
+import { RegisterWebinarButton } from '@features/register-webinar'
+import { AddWebinarToCalendareButton } from '@features/add-webinar-to-calendare'
+import { RemindWebinarButton } from '@features/remind-webinar'
+import { DsCard } from '@shared/uikit/DsCard/DsCard'
+
+export const AccountWebinarCard: React.FC<{ webinar: WebinarDTO }> = ({
+  webinar,
+}) => {
+  const { t } = useTranslation()
+
+  const actionButton = webinar.isPublic ? (
+    <RegisterWebinarButton variant="filled" webinarId={webinar.id}>
+      {t('accountPage.webinars.registration')}
+    </RegisterWebinarButton>
+  ) : (
+    <AddWebinarToCalendareButton variant="filled" itemId={webinar.id}>
+      {t('accountPage.webinars.addToCalendar')}
+    </AddWebinarToCalendareButton>
+  )
+
+  const webinarLocationLabel = webinar.isOnline
+    ? t('accountPage.webinars.location.online')
+    : t('accountPage.webinars.location.offline')
+
+  return (
+    <DsCard>
+      <DsCard.Content>
+        <Stack gap={5}>
+          <Text fw="bold" size="lg" lineClamp={2}>
+            {webinar.title}
+          </Text>
+          <Group gap="xs" mb="sm">
+            <Text size="sm" c="dimmed" lineClamp={2}>
+              {webinar.date}
+            </Text>
+            <Text size="sm" c="dimmed" lineClamp={2}>
+              {webinar.time}
+            </Text>
+            <Text size="sm" c="dimmed" span>
+              ·
+            </Text>
+            <Text size="sm" c="dimmed" lineClamp={2}>
+              {webinarLocationLabel}
+            </Text>
+          </Group>
+
+          {/* card footer */}
+          <Group justify="space-between" align="center">
+            {actionButton}
+            <RemindWebinarButton itemId={webinar.id} />
+          </Group>
+        </Stack>
+      </DsCard.Content>
+    </DsCard>
+  )
+}

--- a/frontend/src/widgets/learning-progress-card/ui/LearningProgressCard.tsx
+++ b/frontend/src/widgets/learning-progress-card/ui/LearningProgressCard.tsx
@@ -10,17 +10,16 @@ import {
 } from '@mantine/core'
 import { useTranslation } from 'react-i18next'
 import { getRelativeDayI18nKey, getDaysDiff } from '@shared/lib'
-import type { TProgress } from '../../../entities/learning-progress/model'
-import { getBadgeConfig } from '@entities/learning-progress/lib/getBadgeConfig'
-import { getBadgeStatus } from '@entities/learning-progress/model/getBadgeStatus'
+import type { LearningProgressDTO } from '@entities/learning-progress'
+import { getBadgeConfig } from '@entities/learning-progress/'
+import { getBadgeStatus } from '@entities/learning-progress/'
 
-interface LearningProgressCardProps {
-  key?: number
-  program: TProgress
+interface ILearningProgressCardProps {
+  program: LearningProgressDTO
   actionButton: React.ReactNode
 }
 
-export const LearningProgressCard: React.FC<LearningProgressCardProps> = ({
+export const LearningProgressCard: React.FC<ILearningProgressCardProps> = ({
   program,
   actionButton,
 }) => {
@@ -63,12 +62,7 @@ export const LearningProgressCard: React.FC<LearningProgressCardProps> = ({
 
         <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
           <Flex justify="space-between" wrap="wrap" align="center">
-            <Text
-              fw="bold"
-              size="lg"
-              lineClamp={2}
-              title={program.programTitle}
-            >
+            <Text fw="bold" size="lg" lineClamp={2}>
               {program.programTitle}
             </Text>
             {badgeConfig && (

--- a/frontend/src/widgets/learning-progress-card/ui/LearningProgressCard.tsx
+++ b/frontend/src/widgets/learning-progress-card/ui/LearningProgressCard.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { getRelativeDayI18nKey, getDaysDiff } from '@shared/lib'
 import type { TProgress } from '../../../entities/learning-progress/model'
-import { getBadgeConfig } from '@entities/learning-progress/ui/lib/getBadgeConfig'
+import { getBadgeConfig } from '@entities/learning-progress/lib/getBadgeConfig'
 import { getBadgeStatus } from '@entities/learning-progress/model/getBadgeStatus'
 
 interface LearningProgressCardProps {


### PR DESCRIPTION
**[Задача: issue-1027](https://github.com/hexlet-volunteers/hexlet-cv/issues/1027)**

**Что сделано:**
- Добавлен раздел «Вебинары» в ЛК: страница `/account/webinars` которая содержит карточки вебинара  с данными (название, дата, время и действия с вебинаром), с пагинацией и пустым состоянием.
- Реализованы кнопки для карточки вебинара: «Записаться», «Добавить в календарь», «Напомнить», а также кнопка «Расписание» в шапке раздела.
- Добавлены мок-данные и MSW-обработчики для вебинаров (`mocks/account/webinars`), чтобы страница работала в dev-окружении и отдавала список с учетом пагинации.

**Сущности и фичи для вебинаров:**
- `entities/webinar` - типы `TWebinar`, `IWebinarsResponse` для списка вебинаров и пагинации.
- `widgets/account-webinar-card` - карточка вебинара с выводом названия, даты/времени, статуса публичности и действий.
- `features/webinar-registration` - кнопка регистрации на публичный вебинар.
- `features/add-to-calendare` - кнопка добавления вебинара в календарь для непубличных/закрытых событий.
- `features/remind-button` - кнопка «Напомнить» для подписки на напоминание о вебинаре.
- `features/open-shedule` - кнопка перехода к общему расписанию вебинаров.

**В процессе сделал рефактор:**
- В LearningProgressCard обновлени иммпорты типа  TProgress и функций getBadgeConfig и getBadgeStatus
- В `learning-progress` функции getBadgeConfig и getBadgeStatusлогика  перенесены в директорию lib.
- Правка верстки в `EmptyPlaceholder` - центрирование title.
<img width="1470" height="799" alt="Снимок экрана 2026-03-13 в 10 43 21" src="https://github.com/user-attachments/assets/b06608db-9de3-48d1-8950-604052bdecff" />
<img width="873" height="783" alt="Снимок экрана 2026-03-13 в 10 43 30" src="https://github.com/user-attachments/assets/3f1830fe-24ac-4a37-a7df-f7e87a5aa33c" />
<img width="775" height="781" alt="Снимок экрана 2026-03-13 в 10 43 38" src="https://github.com/user-attachments/assets/e878f3a4-daaa-4555-9743-72ca9fb5c66f" />
<img width="378" height="781" alt="Снимок экрана 2026-03-13 в 10 48 34" src="https://github.com/user-attachments/assets/2d41bb6b-7d2b-43fd-b448-4a801444f5e3" />
