### PR TITLE
fix: fix duplicate path /admin in URL for help

### DIFF
--- a/src/main/java/io/hexlet/cv/controller/AdminController.java
+++ b/src/main/java/io/hexlet/cv/controller/AdminController.java
@@ -77,7 +77,7 @@ public class AdminController {
         return inertia.render("Admin/Settings/Index", props);
     }
 
-    @GetMapping("/admin/help")
+    @GetMapping("/help")
     public ResponseEntity<?> adminHelpController(HttpServletRequest request) {
         var props = flashPropsService.buildProps(request);
         return inertia.render("Admin/Help/Index", props);


### PR DESCRIPTION
### Description of the problem
Currently, @GetMapping("/admin/help") with @RequestMapping("/admin") results in the URL /admin/admin/help.

### What has been done
Changed the path to @GetMapping("/help"), now the URL will be /admin/help.