### PR TITLE
Restrict page sections API to admins [issue 1055]

### DIFF
--- a/src/main/java/io/hexlet/cv/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/cv/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/admin/**", "/*/admin/**", "/*/admin/").hasRole("ADMIN")
+                        .requestMatchers("/api/pages/sections", "/api/pages/sections/**")
+                                .hasRole("ADMIN")
                         .requestMatchers("/account/**").authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/io/hexlet/cv/controller/PageSectionController.java
+++ b/src/main/java/io/hexlet/cv/controller/PageSectionController.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/pages/sections")
+@PreAuthorize("hasRole('ADMIN')")
 public class PageSectionController {
 
     private final Inertia inertia;

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -28,9 +28,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class PageSectionControllerTest {
 
     @Autowired
@@ -77,9 +79,6 @@ public class PageSectionControllerTest {
     public void testGetAll() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -109,9 +108,6 @@ public class PageSectionControllerTest {
     public void testGetAllWithParams() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -147,9 +143,6 @@ public class PageSectionControllerTest {
     public void testGet() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -174,9 +167,6 @@ public class PageSectionControllerTest {
     public void testCreate() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var adminToken = givenAdminAccessToken();
 
         var template = Instancio.of(modelGenerator.getPageSectionModel()).create();
@@ -210,9 +200,6 @@ public class PageSectionControllerTest {
     public void testUpdate() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -250,9 +237,6 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -279,9 +263,6 @@ public class PageSectionControllerTest {
     public void testPostUnauthorizedReturns401() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var dto = arbitraryPageSectionCreateDto();
 
         // when
@@ -298,9 +279,6 @@ public class PageSectionControllerTest {
     public void testPostAsNonAdminReturns403() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         userRepository.save(User.builder()
                 .email(CANDIDATE_EMAIL)
                 .encryptedPassword(encoder.encode("password"))

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -52,7 +52,7 @@ public class PageSectionControllerTest {
     private BCryptPasswordEncoder encoder;
 
     @Autowired
-    private ObjectMapper om;
+    private ObjectMapper objectMapper;
 
     @Autowired
     private PageSectionMapper pageSectionMapper;
@@ -63,7 +63,6 @@ public class PageSectionControllerTest {
     private static final String ADMIN_EMAIL = "page_section_admin@example.com";
     private static final String CANDIDATE_EMAIL = "page_section_candidate@example.com";
 
-    private String adminToken;
     private PageSection section1;
     private PageSection section2;
 
@@ -71,20 +70,6 @@ public class PageSectionControllerTest {
     public void setUp() {
 
         userRepository.deleteAll();
-        var admin = User.builder()
-                .email(ADMIN_EMAIL)
-                .encryptedPassword(encoder.encode("password"))
-                .role(RoleType.ADMIN)
-                .build();
-        userRepository.save(admin);
-        var candidate = User.builder()
-                .email(CANDIDATE_EMAIL)
-                .encryptedPassword(encoder.encode("password"))
-                .role(RoleType.CANDIDATE)
-                .build();
-        userRepository.save(candidate);
-        adminToken = jwtUtils.generateAccessToken(ADMIN_EMAIL);
-
         pageSectionRepository.deleteAll();
 
         section1 = Instancio.of(modelGenerator.getPageSectionModel()).create();
@@ -99,8 +84,26 @@ public class PageSectionControllerTest {
         pageSectionRepository.save(section2);
     }
 
+    private String givenAdminAccessToken() {
+        userRepository.save(User.builder()
+                .email(ADMIN_EMAIL)
+                .encryptedPassword(encoder.encode("password"))
+                .role(RoleType.ADMIN)
+                .build());
+        return jwtUtils.generateAccessToken(ADMIN_EMAIL);
+    }
+
+    private static PageSectionCreateDTO arbitraryPageSectionCreateDto() {
+        var dto = new PageSectionCreateDTO();
+        dto.setPageKey("somePageKey");
+        dto.setSectionKey("someSectionKey");
+        return dto;
+    }
+
     @Test
     public void testGetAll() throws Exception {
+
+        var adminToken = givenAdminAccessToken();
 
         var response = mockMvc.perform(get("/api/pages/sections")
                 .cookie(new Cookie("access_token", adminToken))
@@ -118,6 +121,8 @@ public class PageSectionControllerTest {
 
     @Test
     public void testGetAllWithParams() throws Exception {
+
+        var adminToken = givenAdminAccessToken();
 
         var section3 = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section3.setPageKey(section1.getPageKey());
@@ -142,6 +147,8 @@ public class PageSectionControllerTest {
     @Test
     public void testGet() throws Exception {
 
+        var adminToken = givenAdminAccessToken();
+
         var response = mockMvc.perform(get("/api/pages/sections/" + section1.getId())
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true"))
@@ -159,6 +166,8 @@ public class PageSectionControllerTest {
     @Test
     public void testCreate() throws Exception {
 
+        var adminToken = givenAdminAccessToken();
+
         pageSectionRepository.delete(section1);
 
         var dto = new PageSectionCreateDTO();
@@ -172,7 +181,7 @@ public class PageSectionControllerTest {
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(dto)))
+                .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isFound());
 
         var section = assertDoesNotThrow(() ->
@@ -186,6 +195,8 @@ public class PageSectionControllerTest {
 
     @Test
     public void testUpdate() throws Exception {
+
+        var adminToken = givenAdminAccessToken();
 
         var dto = new PageSectionUpdateDTO();
         dto.setPageKey(JsonNullable.of("profile"));
@@ -202,7 +213,7 @@ public class PageSectionControllerTest {
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(dto)))
+                .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isSeeOther());
 
         var section = assertDoesNotThrow(() ->
@@ -219,6 +230,8 @@ public class PageSectionControllerTest {
     @Test
     public void testDelete() throws Exception {
 
+        var adminToken = givenAdminAccessToken();
+
         mockMvc.perform(delete("/api/pages/sections/" + section1.getId())
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true"))
@@ -231,29 +244,25 @@ public class PageSectionControllerTest {
     @Test
     public void testPostUnauthorizedReturns401() throws Exception {
 
-        var dto = new PageSectionCreateDTO();
-        dto.setPageKey("x");
-        dto.setSectionKey("y");
-        dto.setTitle("t");
-        dto.setContent("c");
-        dto.setActive(true);
+        var dto = arbitraryPageSectionCreateDto();
 
         mockMvc.perform(post("/api/pages/sections")
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(dto)))
+                .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void testPostAsNonAdminReturns403() throws Exception {
 
-        var dto = new PageSectionCreateDTO();
-        dto.setPageKey("x");
-        dto.setSectionKey("y");
-        dto.setTitle("t");
-        dto.setContent("c");
-        dto.setActive(true);
+        userRepository.save(User.builder()
+                .email(CANDIDATE_EMAIL)
+                .encryptedPassword(encoder.encode("password"))
+                .role(RoleType.CANDIDATE)
+                .build());
+
+        var dto = arbitraryPageSectionCreateDto();
 
         var candidateToken = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
 
@@ -261,7 +270,7 @@ public class PageSectionControllerTest {
                 .cookie(new Cookie("access_token", candidateToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(dto)))
+                .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hexlet.cv.dto.pagesection.PageSectionCreateDTO;
 import io.hexlet.cv.dto.pagesection.PageSectionUpdateDTO;
-import io.hexlet.cv.model.PageSection;
 import io.hexlet.cv.model.User;
 import io.hexlet.cv.model.enums.RoleType;
 import io.hexlet.cv.repository.PageSectionRepository;
@@ -21,6 +20,7 @@ import io.hexlet.cv.util.JWTUtils;
 import io.hexlet.cv.utils.ModelGenerator;
 import jakarta.servlet.http.Cookie;
 import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +58,12 @@ public class PageSectionControllerTest {
     private static final String ADMIN_EMAIL = "page_section_admin@example.com";
     private static final String CANDIDATE_EMAIL = "page_section_candidate@example.com";
 
+    @BeforeEach
+    public void cleanRepositories() {
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+    }
+
     private String givenAdminAccessToken() {
         userRepository.save(User.builder()
                 .email(ADMIN_EMAIL)
@@ -78,9 +84,6 @@ public class PageSectionControllerTest {
     public void testGetAll() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -110,9 +113,6 @@ public class PageSectionControllerTest {
     public void testGetAllWithParams() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -148,9 +148,6 @@ public class PageSectionControllerTest {
     public void testGet() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -175,9 +172,6 @@ public class PageSectionControllerTest {
     public void testCreate() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var adminToken = givenAdminAccessToken();
 
         var template = Instancio.of(modelGenerator.getPageSectionModel()).create();
@@ -211,9 +205,6 @@ public class PageSectionControllerTest {
     public void testUpdate() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -251,9 +242,6 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -280,9 +268,6 @@ public class PageSectionControllerTest {
     public void testPostUnauthorizedReturns401() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         var dto = arbitraryPageSectionCreateDto();
 
         // when
@@ -299,9 +284,6 @@ public class PageSectionControllerTest {
     public void testPostAsNonAdminReturns403() throws Exception {
 
         // given
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
         userRepository.save(User.builder()
                 .email(CANDIDATE_EMAIL)
                 .encryptedPassword(encoder.encode("password"))

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -103,15 +103,16 @@ public class PageSectionControllerTest {
     @Test
     public void testGetAll() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
 
-        var response = mockMvc.perform(get("/api/pages/sections")
+        // when
+        var result = mockMvc.perform(get("/api/pages/sections")
                 .cookie(new Cookie("access_token", adminToken))
-                .header("X-Inertia", "true"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse();
+                .header("X-Inertia", "true"));
 
+        // then
+        var response = result.andExpect(status().isOk()).andReturn().getResponse();
         assertThat(response.getContentAsString())
             .contains(section1.getPageKey())
             .contains(section2.getPageKey())
@@ -122,22 +123,22 @@ public class PageSectionControllerTest {
     @Test
     public void testGetAllWithParams() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
-
         var section3 = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section3.setPageKey(section1.getPageKey());
         section3.setActive(section2.isActive());
         pageSectionRepository.save(section3);
 
-        var response = mockMvc.perform(get("/api/pages/sections")
+        // when
+        var result = mockMvc.perform(get("/api/pages/sections")
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .param("page", section1.getPageKey())
-                .param("active", String.valueOf(section2.isActive())))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse();
+                .param("active", String.valueOf(section2.isActive())));
 
+        // then
+        var response = result.andExpect(status().isOk()).andReturn().getResponse();
         assertThat(response.getContentAsString())
             .doesNotContain(section1.getSectionKey())
             .doesNotContain(section2.getSectionKey())
@@ -147,15 +148,16 @@ public class PageSectionControllerTest {
     @Test
     public void testGet() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
 
-        var response = mockMvc.perform(get("/api/pages/sections/" + section1.getId())
+        // when
+        var result = mockMvc.perform(get("/api/pages/sections/" + section1.getId())
                 .cookie(new Cookie("access_token", adminToken))
-                .header("X-Inertia", "true"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse();
+                .header("X-Inertia", "true"));
 
+        // then
+        var response = result.andExpect(status().isOk()).andReturn().getResponse();
         assertThatJson(response.getContentAsString()).and(
             v -> v.node("props.pageSections[0].id").isEqualTo(section1.getId()),
             v -> v.node("props.pageSections[0].pageKey").isEqualTo(section1.getPageKey()),
@@ -166,10 +168,9 @@ public class PageSectionControllerTest {
     @Test
     public void testCreate() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
-
         pageSectionRepository.delete(section1);
-
         var dto = new PageSectionCreateDTO();
         dto.setPageKey(section1.getPageKey());
         dto.setSectionKey(section1.getSectionKey());
@@ -177,16 +178,17 @@ public class PageSectionControllerTest {
         dto.setContent(section1.getContent());
         dto.setActive(section1.isActive());
 
-        var response = mockMvc.perform(post("/api/pages/sections")
+        // when
+        var result = mockMvc.perform(post("/api/pages/sections")
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(dto)))
-            .andExpect(status().isFound());
+                .content(objectMapper.writeValueAsString(dto)));
 
+        // then
+        result.andExpect(status().isFound());
         var section = assertDoesNotThrow(() ->
             pageSectionRepository.findBySectionKey(dto.getSectionKey()).orElseThrow());
-
         assertThat(section.getPageKey()).isEqualTo(dto.getPageKey());
         assertThat(section.getTitle()).isEqualTo(dto.getTitle());
         assertThat(section.getContent()).isEqualTo(dto.getContent());
@@ -196,33 +198,31 @@ public class PageSectionControllerTest {
     @Test
     public void testUpdate() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
-
         var dto = new PageSectionUpdateDTO();
         dto.setPageKey(JsonNullable.of("profile"));
         dto.setSectionKey(JsonNullable.of("tech_stack"));
         dto.setActive(JsonNullable.of(false));
-
         dto.setTitle(JsonNullable.undefined());
         dto.setContent(JsonNullable.undefined());
-
         var oldTitle = section1.getTitle();
         var oldContent = section1.getContent();
 
-        var response = mockMvc.perform(put("/api/pages/sections/" + section1.getId())
+        // when
+        var result = mockMvc.perform(put("/api/pages/sections/" + section1.getId())
                 .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(dto)))
-            .andExpect(status().isSeeOther());
+                .content(objectMapper.writeValueAsString(dto)));
 
+        // then
+        result.andExpect(status().isSeeOther());
         var section = assertDoesNotThrow(() ->
             pageSectionRepository.findById(section1.getId()).orElseThrow());
-
         assertThat(section.getPageKey()).isEqualTo(dto.getPageKey().get());
         assertThat(section.getSectionKey()).isEqualTo(dto.getSectionKey().get());
         assertThat(section.isActive()).isEqualTo(dto.getActive().get());
-
         assertThat(section.getTitle()).isEqualTo(oldTitle);
         assertThat(section.getContent()).isEqualTo(oldContent);
     }
@@ -230,13 +230,16 @@ public class PageSectionControllerTest {
     @Test
     public void testDelete() throws Exception {
 
+        // given
         var adminToken = givenAdminAccessToken();
 
-        mockMvc.perform(delete("/api/pages/sections/" + section1.getId())
+        // when
+        var result = mockMvc.perform(delete("/api/pages/sections/" + section1.getId())
                 .cookie(new Cookie("access_token", adminToken))
-                .header("X-Inertia", "true"))
-            .andExpect(status().isSeeOther());
+                .header("X-Inertia", "true"));
 
+        // then
+        result.andExpect(status().isSeeOther());
         assertThat(pageSectionRepository.existsById(section1.getId())).isFalse();
         assertThat(pageSectionRepository.existsById(section2.getId())).isTrue();
     }
@@ -244,33 +247,39 @@ public class PageSectionControllerTest {
     @Test
     public void testPostUnauthorizedReturns401() throws Exception {
 
+        // given
         var dto = arbitraryPageSectionCreateDto();
 
-        mockMvc.perform(post("/api/pages/sections")
+        // when
+        var result = mockMvc.perform(post("/api/pages/sections")
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(dto)))
-            .andExpect(status().isUnauthorized());
+                .content(objectMapper.writeValueAsString(dto)));
+
+        // then
+        result.andExpect(status().isUnauthorized());
     }
 
     @Test
     public void testPostAsNonAdminReturns403() throws Exception {
 
+        // given
         userRepository.save(User.builder()
                 .email(CANDIDATE_EMAIL)
                 .encryptedPassword(encoder.encode("password"))
                 .role(RoleType.CANDIDATE)
                 .build());
-
         var dto = arbitraryPageSectionCreateDto();
-
         var candidateToken = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
 
-        mockMvc.perform(post("/api/pages/sections")
+        // when
+        var result = mockMvc.perform(post("/api/pages/sections")
                 .cookie(new Cookie("access_token", candidateToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(dto)))
-            .andExpect(status().isForbidden());
+                .content(objectMapper.writeValueAsString(dto)));
+
+        // then
+        result.andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -20,7 +20,6 @@ import io.hexlet.cv.util.JWTUtils;
 import io.hexlet.cv.utils.ModelGenerator;
 import jakarta.servlet.http.Cookie;
 import org.instancio.Instancio;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,12 +57,6 @@ public class PageSectionControllerTest {
     private static final String ADMIN_EMAIL = "page_section_admin@example.com";
     private static final String CANDIDATE_EMAIL = "page_section_candidate@example.com";
 
-    @BeforeEach
-    public void cleanRepositories() {
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-    }
-
     private String givenAdminAccessToken() {
         userRepository.save(User.builder()
                 .email(ADMIN_EMAIL)
@@ -84,6 +77,9 @@ public class PageSectionControllerTest {
     public void testGetAll() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -113,6 +109,9 @@ public class PageSectionControllerTest {
     public void testGetAllWithParams() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -148,6 +147,9 @@ public class PageSectionControllerTest {
     public void testGet() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -172,6 +174,9 @@ public class PageSectionControllerTest {
     public void testCreate() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var adminToken = givenAdminAccessToken();
 
         var template = Instancio.of(modelGenerator.getPageSectionModel()).create();
@@ -205,6 +210,9 @@ public class PageSectionControllerTest {
     public void testUpdate() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -242,6 +250,9 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
         section1Draft.setPageKey("main");
         var section1 = pageSectionRepository.save(section1Draft);
@@ -268,6 +279,9 @@ public class PageSectionControllerTest {
     public void testPostUnauthorizedReturns401() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var dto = arbitraryPageSectionCreateDto();
 
         // when
@@ -284,6 +298,9 @@ public class PageSectionControllerTest {
     public void testPostAsNonAdminReturns403() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         userRepository.save(User.builder()
                 .email(CANDIDATE_EMAIL)
                 .encryptedPassword(encoder.encode("password"))

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -14,8 +14,13 @@ import io.hexlet.cv.dto.pagesection.PageSectionCreateDTO;
 import io.hexlet.cv.dto.pagesection.PageSectionUpdateDTO;
 import io.hexlet.cv.mapper.PageSectionMapper;
 import io.hexlet.cv.model.PageSection;
+import io.hexlet.cv.model.User;
+import io.hexlet.cv.model.enums.RoleType;
 import io.hexlet.cv.repository.PageSectionRepository;
+import io.hexlet.cv.repository.UserRepository;
+import io.hexlet.cv.util.JWTUtils;
 import io.hexlet.cv.utils.ModelGenerator;
+import jakarta.servlet.http.Cookie;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -37,6 +43,15 @@ public class PageSectionControllerTest {
     private PageSectionRepository pageSectionRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JWTUtils jwtUtils;
+
+    @Autowired
+    private BCryptPasswordEncoder encoder;
+
+    @Autowired
     private ObjectMapper om;
 
     @Autowired
@@ -45,11 +60,30 @@ public class PageSectionControllerTest {
     @Autowired
     private ModelGenerator modelGenerator;
 
+    private static final String ADMIN_EMAIL = "page_section_admin@example.com";
+    private static final String CANDIDATE_EMAIL = "page_section_candidate@example.com";
+
+    private String adminToken;
     private PageSection section1;
     private PageSection section2;
 
     @BeforeEach
     public void setUp() {
+
+        userRepository.deleteAll();
+        var admin = User.builder()
+                .email(ADMIN_EMAIL)
+                .encryptedPassword(encoder.encode("password"))
+                .role(RoleType.ADMIN)
+                .build();
+        userRepository.save(admin);
+        var candidate = User.builder()
+                .email(CANDIDATE_EMAIL)
+                .encryptedPassword(encoder.encode("password"))
+                .role(RoleType.CANDIDATE)
+                .build();
+        userRepository.save(candidate);
+        adminToken = jwtUtils.generateAccessToken(ADMIN_EMAIL);
 
         pageSectionRepository.deleteAll();
 
@@ -69,6 +103,7 @@ public class PageSectionControllerTest {
     public void testGetAll() throws Exception {
 
         var response = mockMvc.perform(get("/api/pages/sections")
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true"))
             .andExpect(status().isOk())
             .andReturn()
@@ -90,6 +125,7 @@ public class PageSectionControllerTest {
         pageSectionRepository.save(section3);
 
         var response = mockMvc.perform(get("/api/pages/sections")
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .param("page", section1.getPageKey())
                 .param("active", String.valueOf(section2.isActive())))
@@ -107,6 +143,7 @@ public class PageSectionControllerTest {
     public void testGet() throws Exception {
 
         var response = mockMvc.perform(get("/api/pages/sections/" + section1.getId())
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true"))
             .andExpect(status().isOk())
             .andReturn()
@@ -132,6 +169,7 @@ public class PageSectionControllerTest {
         dto.setActive(section1.isActive());
 
         var response = mockMvc.perform(post("/api/pages/sections")
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(dto)))
@@ -161,6 +199,7 @@ public class PageSectionControllerTest {
         var oldContent = section1.getContent();
 
         var response = mockMvc.perform(put("/api/pages/sections/" + section1.getId())
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(dto)))
@@ -181,10 +220,48 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         mockMvc.perform(delete("/api/pages/sections/" + section1.getId())
+                .cookie(new Cookie("access_token", adminToken))
                 .header("X-Inertia", "true"))
             .andExpect(status().isSeeOther());
 
         assertThat(pageSectionRepository.existsById(section1.getId())).isFalse();
         assertThat(pageSectionRepository.existsById(section2.getId())).isTrue();
+    }
+
+    @Test
+    public void testPostUnauthorizedReturns401() throws Exception {
+
+        var dto = new PageSectionCreateDTO();
+        dto.setPageKey("x");
+        dto.setSectionKey("y");
+        dto.setTitle("t");
+        dto.setContent("c");
+        dto.setActive(true);
+
+        mockMvc.perform(post("/api/pages/sections")
+                .header("X-Inertia", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(dto)))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testPostAsNonAdminReturns403() throws Exception {
+
+        var dto = new PageSectionCreateDTO();
+        dto.setPageKey("x");
+        dto.setSectionKey("y");
+        dto.setTitle("t");
+        dto.setContent("c");
+        dto.setActive(true);
+
+        var candidateToken = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
+
+        mockMvc.perform(post("/api/pages/sections")
+                .cookie(new Cookie("access_token", candidateToken))
+                .header("X-Inertia", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(dto)))
+            .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -12,7 +12,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hexlet.cv.dto.pagesection.PageSectionCreateDTO;
 import io.hexlet.cv.dto.pagesection.PageSectionUpdateDTO;
-import io.hexlet.cv.mapper.PageSectionMapper;
 import io.hexlet.cv.model.PageSection;
 import io.hexlet.cv.model.User;
 import io.hexlet.cv.model.enums.RoleType;
@@ -22,7 +21,6 @@ import io.hexlet.cv.util.JWTUtils;
 import io.hexlet.cv.utils.ModelGenerator;
 import jakarta.servlet.http.Cookie;
 import org.instancio.Instancio;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openapitools.jackson.nullable.JsonNullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,34 +53,10 @@ public class PageSectionControllerTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private PageSectionMapper pageSectionMapper;
-
-    @Autowired
     private ModelGenerator modelGenerator;
 
     private static final String ADMIN_EMAIL = "page_section_admin@example.com";
     private static final String CANDIDATE_EMAIL = "page_section_candidate@example.com";
-
-    private PageSection section1;
-    private PageSection section2;
-
-    @BeforeEach
-    public void setUp() {
-
-        userRepository.deleteAll();
-        pageSectionRepository.deleteAll();
-
-        section1 = Instancio.of(modelGenerator.getPageSectionModel()).create();
-        section2 = Instancio.of(modelGenerator.getPageSectionModel()).create();
-
-        section1.setPageKey("main");
-        section2.setPageKey("profile");
-
-        section2.setActive(false);
-
-        pageSectionRepository.save(section1);
-        pageSectionRepository.save(section2);
-    }
 
     private String givenAdminAccessToken() {
         userRepository.save(User.builder()
@@ -104,6 +78,18 @@ public class PageSectionControllerTest {
     public void testGetAll() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
+        var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section1Draft.setPageKey("main");
+        var section1 = pageSectionRepository.save(section1Draft);
+
+        var section2Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section2Draft.setPageKey("profile");
+        section2Draft.setActive(false);
+        var section2 = pageSectionRepository.save(section2Draft);
+
         var adminToken = givenAdminAccessToken();
 
         // when
@@ -124,11 +110,24 @@ public class PageSectionControllerTest {
     public void testGetAllWithParams() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
+        var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section1Draft.setPageKey("main");
+        var section1 = pageSectionRepository.save(section1Draft);
+
+        var section2Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section2Draft.setPageKey("profile");
+        section2Draft.setActive(false);
+        var section2 = pageSectionRepository.save(section2Draft);
+
+        var section3Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section3Draft.setPageKey(section1.getPageKey());
+        section3Draft.setActive(section2.isActive());
+        var section3 = pageSectionRepository.save(section3Draft);
+
         var adminToken = givenAdminAccessToken();
-        var section3 = Instancio.of(modelGenerator.getPageSectionModel()).create();
-        section3.setPageKey(section1.getPageKey());
-        section3.setActive(section2.isActive());
-        pageSectionRepository.save(section3);
 
         // when
         var result = mockMvc.perform(get("/api/pages/sections")
@@ -149,6 +148,13 @@ public class PageSectionControllerTest {
     public void testGet() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
+        var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section1Draft.setPageKey("main");
+        var section1 = pageSectionRepository.save(section1Draft);
+
         var adminToken = givenAdminAccessToken();
 
         // when
@@ -169,14 +175,20 @@ public class PageSectionControllerTest {
     public void testCreate() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var adminToken = givenAdminAccessToken();
-        pageSectionRepository.delete(section1);
+
+        var template = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        template.setPageKey("main");
+
         var dto = new PageSectionCreateDTO();
-        dto.setPageKey(section1.getPageKey());
-        dto.setSectionKey(section1.getSectionKey());
-        dto.setTitle(section1.getTitle());
-        dto.setContent(section1.getContent());
-        dto.setActive(section1.isActive());
+        dto.setPageKey(template.getPageKey());
+        dto.setSectionKey(template.getSectionKey());
+        dto.setTitle(template.getTitle());
+        dto.setContent(template.getContent());
+        dto.setActive(template.isActive());
 
         // when
         var result = mockMvc.perform(post("/api/pages/sections")
@@ -199,7 +211,15 @@ public class PageSectionControllerTest {
     public void testUpdate() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
+        var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section1Draft.setPageKey("main");
+        var section1 = pageSectionRepository.save(section1Draft);
+
         var adminToken = givenAdminAccessToken();
+
         var dto = new PageSectionUpdateDTO();
         dto.setPageKey(JsonNullable.of("profile"));
         dto.setSectionKey(JsonNullable.of("tech_stack"));
@@ -231,6 +251,18 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
+        var section1Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section1Draft.setPageKey("main");
+        var section1 = pageSectionRepository.save(section1Draft);
+
+        var section2Draft = Instancio.of(modelGenerator.getPageSectionModel()).create();
+        section2Draft.setPageKey("profile");
+        section2Draft.setActive(false);
+        var section2 = pageSectionRepository.save(section2Draft);
+
         var adminToken = givenAdminAccessToken();
 
         // when
@@ -248,6 +280,9 @@ public class PageSectionControllerTest {
     public void testPostUnauthorizedReturns401() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         var dto = arbitraryPageSectionCreateDto();
 
         // when
@@ -264,6 +299,9 @@ public class PageSectionControllerTest {
     public void testPostAsNonAdminReturns403() throws Exception {
 
         // given
+        userRepository.deleteAll();
+        pageSectionRepository.deleteAll();
+
         userRepository.save(User.builder()
                 .email(CANDIDATE_EMAIL)
                 .encryptedPassword(encoder.encode("password"))


### PR DESCRIPTION
Summary
Restricts /api/pages/sections to users with the ADMIN role so unauthenticated and non-admin clients cannot call these endpoints.

Changes

1. PageSectionController: class-level @PreAuthorize("hasRole('ADMIN')"), same pattern as other admin controllers.
2. SecurityConfig: hasRole("ADMIN") for /api/pages/sections and /api/pages/sections/** so OAuth2 Resource Server returns 401 when there is no JWT (method security alone would often yield 403 for anonymous requests on permitAll() routes).
3. PageSectionControllerTest: JWT cookie for admin on successful flows; tests for 401 (no token) and 403 (candidate user) on POST.