### PR TITLE
del log from itertia.provider.tsx

### DIFF
--- a/frontend/src/app/providers/inertia/inertia.provider.tsx
+++ b/frontend/src/app/providers/inertia/inertia.provider.tsx
@@ -9,7 +9,6 @@ export const initInertia = (page?: Page) => {
   createInertiaApp({
     page: page ? page : undefined,
     resolve: (name) => {
-      console.log('Inertia ищет компонент:', name)
       const pages = import.meta.glob('../../../pages/**/*.tsx', { eager: true })
       const page = pages[`../../../pages/${name}.tsx`]
       if (!page) throw new Error(`Page not found: ${name}`)


### PR DESCRIPTION
Добрый день!
сделала вот эту задачку. #1062 

В коде остались debug-логи:
Home.tsx:46 — console.log('Page sections:', pageSections)
inertia.provider.tsx:12 — console.log('Inertia ищет компонент:', name)
Proposed solution
Предлагаемое решение
Удалить оба console.log
Критерии приёмки
В продакшн-коде нет console.log

В Home.tsx, видать, кто-то уже исправил, нет там лога, подправила inertia.provider.tsx