### PR TITLE
feat(security): enable CSRF for state-changing requests (#1056)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@mantine/hooks": "^8.2.1",
         "@tabler/icons-react": "^3.36.1",
         "@types/node": "^24.12.0",
+        "axios": "^1.13.6",
         "i18next": "^25.6.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "react": "^18.2.0",
@@ -1079,17 +1080,6 @@
         "qs": "^6.14.0"
       }
     },
-    "node_modules/@inertiajs/core/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@inertiajs/inertia": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.1.tgz",
@@ -1099,6 +1089,15 @@
         "axios": "^0.21.1",
         "deepmerge": "^4.0.0",
         "qs": "^6.9.0"
+      }
+    },
+    "node_modules/@inertiajs/inertia/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@inertiajs/progress": {
@@ -2434,12 +2433,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5557,10 +5558,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@mantine/hooks": "^8.2.1",
     "@tabler/icons-react": "^3.36.1",
     "@types/node": "^24.12.0",
+    "axios": "^1.13.6",
     "i18next": "^25.6.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "react": "^18.2.0",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,12 +1,18 @@
+import axios from 'axios'
 import { initInertia } from '@inertia/inertia.provider'
 import { enableMocking } from '@mocks/enableMocking'
 
+axios.defaults.withCredentials = true
+axios.defaults.xsrfCookieName = 'XSRF-TOKEN'
+axios.defaults.xsrfHeaderName = 'X-XSRF-TOKEN'
+
 async function getInitialPage() {
   const res = await fetch(window.location.href, {
+    credentials: 'include',
     headers: {
       'X-Inertia': 'true',
       'X-Requested-With': 'XMLHttpRequest',
-      'Accept': 'application/json',
+      Accept: 'application/json',
     },
   })
 

--- a/src/main/java/io/hexlet/cv/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/cv/config/SecurityConfig.java
@@ -26,6 +26,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -41,9 +43,17 @@ public class SecurityConfig {
                                  BearerTokenResolver cookieTokenResolver,
                                  Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthConverter)
             throws Exception {
+        var csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        csrfTokenRepository.setCookiePath("/");
+
+        var csrfHandler = new XorCsrfTokenRequestAttributeHandler();
+        csrfHandler.setCsrfRequestAttributeName("_csrf");
+
         http
                 .cors(Customizer.withDefaults())
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(csrfTokenRepository)
+                        .csrfTokenRequestHandler(csrfHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/admin/**", "/*/admin/**", "/*/admin/").hasRole("ADMIN")
                         .requestMatchers("/account/**").authenticated()
@@ -76,6 +86,7 @@ public class SecurityConfig {
                 "Authorization",
                 "Content-Type",
                 "X-Requested-With",
+                "X-XSRF-TOKEN",
                 "X-Inertia",
                 "X-Inertia-Version",
                 "Accept",

--- a/src/test/java/io/hexlet/cv/controller/ArticleControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package io.hexlet.cv.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -152,6 +153,7 @@ public class ArticleControllerTest {
             """;
 
         mockMvc.perform(post("/admin/marketing/articles")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -175,6 +177,7 @@ public class ArticleControllerTest {
             """;
 
         mockMvc.perform(put("/admin/marketing/articles/{id}", testArticle.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -192,6 +195,7 @@ public class ArticleControllerTest {
         var articleId = testArticle.getId();
 
         mockMvc.perform(delete("/admin/marketing/articles/{id}", testArticle.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isSeeOther())
@@ -206,6 +210,7 @@ public class ArticleControllerTest {
         boolean initialHomepage = testArticle.getShowOnHomepage();
 
         mockMvc.perform(post("/admin/marketing/articles/{id}/toggle-homepage", testArticle.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -223,6 +228,7 @@ public class ArticleControllerTest {
         boolean initialPublished = testArticle.getIsPublished();
 
         mockMvc.perform(post("/admin/marketing/articles/{id}/toggle-publish", testArticle.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -240,6 +246,7 @@ public class ArticleControllerTest {
         String json = "{\"display_order\": 5}";
 
         mockMvc.perform(put("/admin/marketing/articles/{id}/display-order", testArticle.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))

--- a/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
@@ -1,6 +1,7 @@
 package io.hexlet.cv.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -176,6 +177,7 @@ public class LearningProgressControllerTest {
     @Test
     void testStartProgram() throws Exception {
         mockMvc.perform(post("/account/my-progress/program/start")
+                        .with(csrf())
                         .param("programId", testProgram.getId().toString())
                         .cookie(new Cookie("access_token", candidateToken))
                         .header("X-Inertia", "true"))
@@ -190,6 +192,7 @@ public class LearningProgressControllerTest {
     @Test
     void testStartLesson() throws Exception {
         mockMvc.perform(post("/account/my-progress/lesson/start")
+                        .with(csrf())
                         .param("programProgressId", testProgramProgress.getId().toString())
                         .param("lessonId", testLesson.getId().toString())
                         .cookie(new Cookie("access_token", candidateToken))
@@ -215,6 +218,7 @@ public class LearningProgressControllerTest {
         lessonProgress = userLessonProgressRepository.save(lessonProgress);
 
         mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
+                        .with(csrf())
                         .param("programProgressId", testProgramProgress.getId().toString())
                         .cookie(new Cookie("access_token", candidateToken))
                         .header("X-Inertia", "true"))
@@ -232,6 +236,7 @@ public class LearningProgressControllerTest {
     @Test
     void testCompleteProgram() throws Exception {
         mockMvc.perform(post("/account/my-progress/program/" + testProgramProgress.getId() + "/complete")
+                        .with(csrf())
                         .param("programProgressId", testProgramProgress.getId().toString())
                         .cookie(new Cookie("access_token", candidateToken))
                         .header("X-Inertia", "true"))

--- a/src/test/java/io/hexlet/cv/controller/LoginControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/LoginControllerTest.java
@@ -1,6 +1,7 @@
 package io.hexlet.cv.controller;
 
 import static org.hamcrest.Matchers.hasKey;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -84,7 +85,7 @@ public class LoginControllerTest {
         var request = post("/users/sign_in").contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(data));
 
-        mockMvc.perform(request).andExpect(status().isFound())
+        mockMvc.perform(request.with(csrf())).andExpect(status().isFound())
                 .andExpect(header().stringValues(HttpHeaders.SET_COOKIE,
                         Matchers.hasItem(Matchers.containsString("access_token"))))
                 .andExpect(header().stringValues(HttpHeaders.SET_COOKIE,
@@ -101,7 +102,7 @@ public class LoginControllerTest {
         var request = post("/users/sign_in").contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(data));
 
-        mockMvc.perform(request).andExpect(status().isUnauthorized())
+        mockMvc.perform(request.with(csrf())).andExpect(status().isUnauthorized())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.email")
                         .value("Пользователь не найден"));
@@ -116,7 +117,7 @@ public class LoginControllerTest {
         var request = post("/users/sign_in").contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(data));
 
-        mockMvc.perform(request).andExpect(status().isUnauthorized())
+        mockMvc.perform(request.with(csrf())).andExpect(status().isUnauthorized())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.password")
                         .value("Неверный пароль"));
@@ -130,6 +131,7 @@ public class LoginControllerTest {
         dto.setPassword("another_password");
 
         mockMvc.perform(post("/users/sign_in")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -148,6 +150,7 @@ public class LoginControllerTest {
         dto.setPassword(testPassword);
 
         mockMvc.perform(post("/users/sign_in")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -166,6 +169,7 @@ public class LoginControllerTest {
         dto.setPassword(testPassword);
 
         mockMvc.perform(post("/users/sign_in")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")

--- a/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PageSectionControllerTest.java
@@ -3,6 +3,7 @@ package io.hexlet.cv.controller;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -132,6 +133,7 @@ public class PageSectionControllerTest {
         dto.setActive(section1.isActive());
 
         var response = mockMvc.perform(post("/api/pages/sections")
+                .with(csrf())
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(dto)))
@@ -144,6 +146,22 @@ public class PageSectionControllerTest {
         assertThat(section.getTitle()).isEqualTo(dto.getTitle());
         assertThat(section.getContent()).isEqualTo(dto.getContent());
         assertThat(section.isActive()).isEqualTo(dto.getActive());
+    }
+
+    @Test
+    public void testCreateRejectedWithoutCsrfToken() throws Exception {
+        var dto = new PageSectionCreateDTO();
+        dto.setPageKey("main");
+        dto.setSectionKey("csrf_test_section");
+        dto.setTitle("t");
+        dto.setContent("c");
+        dto.setActive(true);
+
+        mockMvc.perform(post("/api/pages/sections")
+                .header("X-Inertia", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(dto)))
+            .andExpect(status().isForbidden());
     }
 
     @Test
@@ -161,6 +179,7 @@ public class PageSectionControllerTest {
         var oldContent = section1.getContent();
 
         var response = mockMvc.perform(put("/api/pages/sections/" + section1.getId())
+                .with(csrf())
                 .header("X-Inertia", "true")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(dto)))
@@ -181,6 +200,7 @@ public class PageSectionControllerTest {
     public void testDelete() throws Exception {
 
         mockMvc.perform(delete("/api/pages/sections/" + section1.getId())
+                .with(csrf())
                 .header("X-Inertia", "true"))
             .andExpect(status().isSeeOther());
 

--- a/src/test/java/io/hexlet/cv/controller/PricingPlanControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PricingPlanControllerTest.java
@@ -2,6 +2,7 @@ package io.hexlet.cv.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -179,6 +180,7 @@ public class PricingPlanControllerTest {
                 """;
 
         mockMvc.perform(post("/admin/marketing/pricing")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createPricingJson)
@@ -208,6 +210,7 @@ public class PricingPlanControllerTest {
                 """;
 
         mockMvc.perform(post("/admin/marketing/pricing")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", candidateToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createPricingJson))
@@ -227,6 +230,7 @@ public class PricingPlanControllerTest {
                 """;
 
         mockMvc.perform(post("/admin/marketing/pricing")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidPricingJson))
@@ -250,6 +254,7 @@ public class PricingPlanControllerTest {
                 """;
 
         mockMvc.perform(put("/admin/marketing/pricing/" + pricingPlan.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(updatePricingJson)
@@ -276,6 +281,7 @@ public class PricingPlanControllerTest {
                 """;
 
         mockMvc.perform(put("/admin/marketing/pricing/99999")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(updatePricingJson))
@@ -291,6 +297,7 @@ public class PricingPlanControllerTest {
         var planId = pricingPlan.getId();
 
         mockMvc.perform(delete("/admin/marketing/pricing/" + planId)
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isSeeOther())
@@ -308,6 +315,7 @@ public class PricingPlanControllerTest {
         var pricingPlan = createPricingPlan("План на удаление", 200.0, 20.0);
 
         mockMvc.perform(delete("/admin/marketing/pricing/" + pricingPlan.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", candidateToken)))
                 .andExpect(status().isForbidden());
     }

--- a/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
@@ -2,6 +2,7 @@ package io.hexlet.cv.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasKey;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -74,7 +75,7 @@ public class RegistrationControllerTest {
         var request = post("/users").contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(data));
 
-        mockMvc.perform(request).andExpect(status().isFound());
+        mockMvc.perform(request.with(csrf())).andExpect(status().isFound());
 
         var user = userRepository.findByEmail(data.getEmail()).orElse(null);
         assertThat(user).isNotNull();
@@ -92,6 +93,7 @@ public class RegistrationControllerTest {
                 .content(om.writeValueAsString(data));
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -110,7 +112,7 @@ public class RegistrationControllerTest {
         var request = post("/users").contentType(MediaType.APPLICATION_JSON)
                 .content(om.writeValueAsString(data));
 
-        mockMvc.perform(request).andExpect(status().isConflict());
+        mockMvc.perform(request.with(csrf())).andExpect(status().isConflict());
     }
 
     @Test
@@ -127,6 +129,7 @@ public class RegistrationControllerTest {
                 .content(om.writeValueAsString(data));
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -143,6 +146,7 @@ public class RegistrationControllerTest {
                 .content(om.writeValueAsString(data));
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -179,6 +183,7 @@ public class RegistrationControllerTest {
         data.setPassword("test_p");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -192,6 +197,7 @@ public class RegistrationControllerTest {
         // имя совпадает
         data.setPassword("firstName");
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -200,6 +206,7 @@ public class RegistrationControllerTest {
         // фамилия совпадает
         data.setPassword("lastName");
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -208,6 +215,7 @@ public class RegistrationControllerTest {
         // email совпадает
         data.setPassword("test@gmail.com");
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
                 .andExpect(status().isUnprocessableEntity())
@@ -233,6 +241,7 @@ public class RegistrationControllerTest {
         dto.setEmail("test@google.com");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -251,6 +260,7 @@ public class RegistrationControllerTest {
         dto.setPassword("firstName");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -267,6 +277,7 @@ public class RegistrationControllerTest {
         dto.setPassword("test_p");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -283,6 +294,7 @@ public class RegistrationControllerTest {
         dto.setEmail("testgmail.com");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -299,6 +311,7 @@ public class RegistrationControllerTest {
         dto.setEmail("test@goopmal.com");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -315,6 +328,7 @@ public class RegistrationControllerTest {
         dto.setEmail("test@sharklasers.com");
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")
@@ -330,6 +344,7 @@ public class RegistrationControllerTest {
         var dto = createValidDto();
 
         mockMvc.perform(post("/users")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(dto))
                         .header("X-Inertia", "true")

--- a/src/test/java/io/hexlet/cv/controller/ReviewControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/ReviewControllerTest.java
@@ -3,6 +3,7 @@ package io.hexlet.cv.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -155,6 +156,7 @@ public class ReviewControllerTest {
             """;
 
         mockMvc.perform(post("/admin/marketing/reviews")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -190,6 +192,7 @@ public class ReviewControllerTest {
             """;
 
         mockMvc.perform(put("/admin/marketing/reviews/{id}", testReview.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -214,6 +217,7 @@ public class ReviewControllerTest {
         var reviewId = testReview.getId();
 
         mockMvc.perform(delete("/admin/marketing/reviews/{id}", testReview.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isSeeOther())
@@ -231,6 +235,7 @@ public class ReviewControllerTest {
         boolean initialPublished = testReview.getIsPublished();
 
         mockMvc.perform(post("/admin/marketing/reviews/{id}/toggle-publish", testReview.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -249,6 +254,7 @@ public class ReviewControllerTest {
         boolean initialHomepage = testReview.getShowOnHomepage();
 
         mockMvc.perform(post("/admin/marketing/reviews/{id}/toggle-homepage", testReview.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -268,6 +274,7 @@ public class ReviewControllerTest {
         String json = "{\"display_order\": 3}";
 
         mockMvc.perform(put("/admin/marketing/reviews/{id}/display-order", testReview.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))

--- a/src/test/java/io/hexlet/cv/controller/StoryControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/StoryControllerTest.java
@@ -3,6 +3,7 @@ package io.hexlet.cv.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -155,6 +156,7 @@ public class StoryControllerTest {
                 """;
 
         mockMvc.perform(post("/admin/marketing/stories")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -190,6 +192,7 @@ public class StoryControllerTest {
             """;
 
         mockMvc.perform(put("/admin/marketing/stories/{id}", testStory.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -214,6 +217,7 @@ public class StoryControllerTest {
         var storyId = testStory.getId();
 
         mockMvc.perform(delete("/admin/marketing/stories/{id}", testStory.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isSeeOther())
@@ -230,6 +234,7 @@ public class StoryControllerTest {
         boolean initialPublishStatus = testStory.getIsPublished();
 
         mockMvc.perform(post("/admin/marketing/stories/{id}/toggle-publish", testStory.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -247,6 +252,7 @@ public class StoryControllerTest {
         boolean initialHomepageStatus = testStory.getShowOnHomepage();
 
         mockMvc.perform(post("/admin/marketing/stories/{id}/toggle-homepage", testStory.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -265,6 +271,7 @@ public class StoryControllerTest {
         String json = "{\"display_order\": 5}";
 
         mockMvc.perform(put("/admin/marketing/stories/{id}/display-order", testStory.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))

--- a/src/test/java/io/hexlet/cv/controller/TeamControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/TeamControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -170,6 +171,7 @@ public class TeamControllerTest {
                 """;
 
         mockMvc.perform(post("/admin/marketing/team")
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -209,6 +211,7 @@ public class TeamControllerTest {
                 """;
 
         mockMvc.perform(put("/admin/marketing/team/{id}", testTeam.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -236,6 +239,7 @@ public class TeamControllerTest {
         Long teamId = testTeam.getId();
 
         mockMvc.perform(delete("/admin/marketing/team/{id}", testTeam.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isSeeOther())
@@ -252,6 +256,7 @@ public class TeamControllerTest {
         boolean initialPublishStatus = testTeam.getIsPublished();
 
         mockMvc.perform(post("/admin/marketing/team/{id}/toggle-publish", testTeam.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -269,6 +274,7 @@ public class TeamControllerTest {
         boolean initialHomepageStatus = testTeam.getShowOnHomepage();
 
         mockMvc.perform(post("/admin/marketing/team/{id}/toggle-homepage", testTeam.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isFound())
@@ -287,6 +293,7 @@ public class TeamControllerTest {
         String json = "{\"display_order\": 3}";
 
         mockMvc.perform(put("/admin/marketing/team/{id}/display-order", testTeam.getId())
+                        .with(csrf())
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))


### PR DESCRIPTION
Replace global csrf.disable() with CookieCsrfTokenRepository and XorCsrfTokenRequestAttributeHandler. Expose X-XSRF-TOKEN in CORS. Configure Inertia/axios xsrf defaults and include credentials on initial fetch. Add csrf() to MockMvc mutation tests and a negative API test without token. Declare axios as a direct frontend dependency.