### PR TITLE
[feat-1057] добавлена проверка прав в сервисах прогресса урока и программы 

### DIFF
--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -112,15 +112,13 @@ public class LearningProgressController {
     @PostMapping("/lesson/{lessonProgressId}/complete")
     public Object completeLesson(@PathVariable Long lessonProgressId,
                                  @RequestParam Long programProgressId) {
-        var user = userUtils.getCurrentUser();
-        userLessonProgressService.completeLesson(lessonProgressId, user.getId());
+        userLessonProgressService.completeLesson(lessonProgressId);
         return inertia.redirect("/account/my-progress/program/" + programProgressId + "/lessons");
     }
 
     @PostMapping("/program/{programProgressId}/complete")
     public Object completeProgram(@PathVariable Long programProgressId) {
-        var user = userUtils.getCurrentUser();
-        userProgramProgressService.completeProgram(programProgressId, user.getId());
+        userProgramProgressService.completeProgram(programProgressId);
         return inertia.redirect("/account/my-progress");
     }
 

--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -112,13 +112,15 @@ public class LearningProgressController {
     @PostMapping("/lesson/{lessonProgressId}/complete")
     public Object completeLesson(@PathVariable Long lessonProgressId,
                                  @RequestParam Long programProgressId) {
-        userLessonProgressService.completeLesson(lessonProgressId);
+        var user = userUtils.getCurrentUser();
+        userLessonProgressService.completeLesson(lessonProgressId, user.getId());
         return inertia.redirect("/account/my-progress/program/" + programProgressId + "/lessons");
     }
 
     @PostMapping("/program/{programProgressId}/complete")
     public Object completeProgram(@PathVariable Long programProgressId) {
-        userProgramProgressService.completeProgram(programProgressId);
+        var user = userUtils.getCurrentUser();
+        userProgramProgressService.completeProgram(programProgressId, user.getId());
         return inertia.redirect("/account/my-progress");
     }
 

--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -29,7 +29,6 @@ public class GlobalExceptionHandler {
                                 HttpServletRequest request,
                                 RedirectAttributes redirectAttributes,
                                 HttpStatus status) {
-
         // Обработка AJAX-запроса (Inertia)
         if ("true".equals(request.getHeader("X-Inertia"))) {
             redirectAttributes.addFlashAttribute("errors", errors);
@@ -127,10 +126,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
-    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException e) {
-        return ResponseEntity
-                .status(HttpStatus.FORBIDDEN)
-                .body(Map.of("error", e.getMessage()));
+    public Object handleAccessDenied(AccessDeniedException ex,
+                                     HttpServletRequest request,
+                                     RedirectAttributes redirectAttributes) {
+        Map<String, String> errors = Map.of("Access denied error", ex.getMessage());
+        if ("true".equals(request.getHeader("X-Inertia"))) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("errors", errors));
+        }
+        return commonHandle(errors, request, redirectAttributes, HttpStatus.FORBIDDEN);
     }
 
 // это просто ошибки все остальное

--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -13,10 +13,12 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -121,6 +123,14 @@ public class GlobalExceptionHandler {
 
         Map<String, String> errors = Map.of("password", ex.getMessage());
         return commonHandle(errors, request, redirectAttributes, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", e.getMessage()));
     }
 
 // это просто ошибки все остальное

--- a/src/main/java/io/hexlet/cv/service/UserLessonProgressService.java
+++ b/src/main/java/io/hexlet/cv/service/UserLessonProgressService.java
@@ -8,6 +8,9 @@ import io.hexlet.cv.repository.LessonRepository;
 import io.hexlet.cv.repository.UserLessonProgressRepository;
 import io.hexlet.cv.repository.UserProgramProgressRepository;
 import io.hexlet.cv.repository.UserRepository;
+
+
+import org.springframework.security.access.AccessDeniedException;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -76,9 +79,13 @@ public class UserLessonProgressService {
     }
 
     @Transactional
-    public void completeLesson(Long progressId) {
+    public void completeLesson(Long progressId, Long userId) {
         var progress = userLessonProgressRepository.findById(progressId)
                 .orElseThrow(() -> new ResourceNotFoundException("lesson.progress.not.found" + progressId));
+
+        if (!progress.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException("Access denied");
+        }
 
         LocalDateTime now = LocalDateTime.now(clock);
         progress.setIsCompleted(true);

--- a/src/main/java/io/hexlet/cv/service/UserLessonProgressService.java
+++ b/src/main/java/io/hexlet/cv/service/UserLessonProgressService.java
@@ -10,6 +10,7 @@ import io.hexlet.cv.repository.UserProgramProgressRepository;
 import io.hexlet.cv.repository.UserRepository;
 
 
+import io.hexlet.cv.util.UserUtils;
 import org.springframework.security.access.AccessDeniedException;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -33,6 +34,7 @@ public class UserLessonProgressService {
     private final LessonRepository lessonRepository;
     private final UserRepository userRepository;
     private final Clock clock;
+    private final UserUtils userUtils;
 
     public Page<UserLessonProgressDTO> getLessonProgress(Long userId, Long programProgressId, Pageable pageable) {
         log.debug("Getting lessons for user{}, programProgress {} (pageable={})", userId, programProgressId, pageable);
@@ -79,12 +81,13 @@ public class UserLessonProgressService {
     }
 
     @Transactional
-    public void completeLesson(Long progressId, Long userId) {
+    public void completeLesson(Long progressId) {
+        Long userId = userUtils.getCurrentUser().getId();
         var progress = userLessonProgressRepository.findById(progressId)
                 .orElseThrow(() -> new ResourceNotFoundException("lesson.progress.not.found" + progressId));
 
         if (!progress.getUser().getId().equals(userId)) {
-            throw new AccessDeniedException("Access denied");
+            throw new AccessDeniedException("User cannot access this lesson");
         }
 
         LocalDateTime now = LocalDateTime.now(clock);

--- a/src/main/java/io/hexlet/cv/service/UserProgramProgressService.java
+++ b/src/main/java/io/hexlet/cv/service/UserProgramProgressService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -72,10 +73,14 @@ public class UserProgramProgressService {
     }
 
     @Transactional
-    public void completeProgram(Long progressId) {
+    public void completeProgram(Long progressId, Long userId) {
         log.debug("Completing program progress {}", progressId);
         var progress = programProgressRepository.findById(progressId)
                 .orElseThrow(() -> new ResourceNotFoundException("program.progress.not.found"));
+
+        if (!progress.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException("Access denied");
+        }
 
         LocalDateTime now = LocalDateTime.now(clock);
         int totalLessons = progress.getProgram().getLessons().size();

--- a/src/main/java/io/hexlet/cv/service/UserProgramProgressService.java
+++ b/src/main/java/io/hexlet/cv/service/UserProgramProgressService.java
@@ -7,6 +7,7 @@ import io.hexlet.cv.model.learning.UserProgramProgress;
 import io.hexlet.cv.repository.ProgramRepository;
 import io.hexlet.cv.repository.UserProgramProgressRepository;
 import io.hexlet.cv.repository.UserRepository;
+import io.hexlet.cv.util.UserUtils;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ public class UserProgramProgressService {
     private final UserRepository userRepository;
     private final ProgramRepository programRepository;
     private final Clock clock;
+    private final UserUtils userUtils;
 
     public Page<UserProgramProgressDTO> getUserProgress(Long userId, Pageable pageable) {
         log.debug("Getting progress for user {} (pageable={})", userId, pageable);
@@ -73,13 +75,15 @@ public class UserProgramProgressService {
     }
 
     @Transactional
-    public void completeProgram(Long progressId, Long userId) {
+    public void completeProgram(Long progressId) {
         log.debug("Completing program progress {}", progressId);
+
+        Long userId = userUtils.getCurrentUser().getId();
         var progress = programProgressRepository.findById(progressId)
                 .orElseThrow(() -> new ResourceNotFoundException("program.progress.not.found"));
 
         if (!progress.getUser().getId().equals(userId)) {
-            throw new AccessDeniedException("Access denied");
+            throw new AccessDeniedException("User cannot access this program");
         }
 
         LocalDateTime now = LocalDateTime.now(clock);

--- a/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
@@ -65,6 +65,9 @@ public class LearningProgressControllerTest {
     private Program testProgram;
     private Lesson testLesson;
     private UserProgramProgress testProgramProgress;
+    private User anotherUser;
+    private String anotherToken;
+    private static final String ANOTHER_EMAIL = "another_user@example.com";
 
 
     @AfterEach
@@ -87,6 +90,13 @@ public class LearningProgressControllerTest {
         testUser = userRepository.save(testUser);
 
         candidateToken = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
+
+        anotherUser = new User();
+        anotherUser.setEmail(ANOTHER_EMAIL);
+        anotherUser.setEncryptedPassword(passwordEncoder.encode("another_password"));
+        anotherUser.setRole(RoleType.CANDIDATE);
+        anotherUser = userRepository.save(anotherUser);
+        anotherToken = jwtUtils.generateAccessToken(ANOTHER_EMAIL);
 
         testProgram = new Program();
         testProgram.setTitle("Test Program");
@@ -299,5 +309,31 @@ public class LearningProgressControllerTest {
                         .cookie(new Cookie("access_token", candidateToken))
                         .header("X-Inertia", "true"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void completeLessonByAnotherUserReturnsForbidden() throws Exception {
+        UserLessonProgress lessonProgress = new UserLessonProgress();
+        lessonProgress.setUser(testUser);
+        lessonProgress.setLesson(testLesson);
+        lessonProgress.setProgramProgress(testProgramProgress);
+        lessonProgress.setStartedAt(LocalDateTime.now());
+        lessonProgress.setIsCompleted(false);
+        lessonProgress = userLessonProgressRepository.save(lessonProgress);
+
+        mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
+                .param("programProgressId", testProgramProgress.getId().toString())
+                .cookie(new Cookie("access_token", anotherToken))
+                .header("X-Inertia", true))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void completeProgramByAnotherUserReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/account/my-progress/program/" + testProgramProgress.getId() + "/complete")
+                        .param("programProgressId", testProgramProgress.getId().toString())
+                        .cookie(new Cookie("access_token", anotherToken))
+                        .header("X-Inertia", true))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/LearningProgressControllerTest.java
@@ -1,339 +1,416 @@
-package io.hexlet.cv.controller;
+    package io.hexlet.cv.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+    import static org.assertj.core.api.Assertions.assertThat;
+    import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+    import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+    import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.hexlet.cv.model.User;
-import io.hexlet.cv.model.admin.programs.Lesson;
-import io.hexlet.cv.model.admin.programs.Program;
-import io.hexlet.cv.model.enums.RoleType;
-import io.hexlet.cv.model.learning.UserLessonProgress;
-import io.hexlet.cv.model.learning.UserProgramProgress;
-import io.hexlet.cv.repository.LessonRepository;
-import io.hexlet.cv.repository.ProgramRepository;
-import io.hexlet.cv.repository.UserLessonProgressRepository;
-import io.hexlet.cv.repository.UserProgramProgressRepository;
-import io.hexlet.cv.repository.UserRepository;
-import io.hexlet.cv.util.JWTUtils;
-import jakarta.servlet.http.Cookie;
-import java.time.LocalDateTime;
-import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
+    import io.hexlet.cv.model.User;
+    import io.hexlet.cv.model.admin.programs.Lesson;
+    import io.hexlet.cv.model.admin.programs.Program;
+    import io.hexlet.cv.model.enums.RoleType;
+    import io.hexlet.cv.model.learning.UserLessonProgress;
+    import io.hexlet.cv.model.learning.UserProgramProgress;
+    import io.hexlet.cv.repository.LessonRepository;
+    import io.hexlet.cv.repository.ProgramRepository;
+    import io.hexlet.cv.repository.UserLessonProgressRepository;
+    import io.hexlet.cv.repository.UserProgramProgressRepository;
+    import io.hexlet.cv.repository.UserRepository;
+    import io.hexlet.cv.util.JWTUtils;
+    import jakarta.servlet.http.Cookie;
+    import java.time.LocalDateTime;
+    import java.util.Optional;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class LearningProgressControllerTest {
+    import org.junit.jupiter.api.AfterEach;
+    import org.junit.jupiter.api.Test;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+    import org.springframework.boot.test.context.SpringBootTest;
+    import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+    import org.springframework.test.web.servlet.MockMvc;
+    import org.springframework.test.web.servlet.MvcResult;
+    import org.springframework.test.web.servlet.ResultActions;
 
-    @Autowired
-    private MockMvc mockMvc;
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    public class LearningProgressControllerTest {
 
-    @Autowired
-    private UserRepository userRepository;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private JWTUtils jwtUtils;
+        @Autowired
+        private UserRepository userRepository;
 
-    @Autowired
-    private BCryptPasswordEncoder passwordEncoder;
+        @Autowired
+        private JWTUtils jwtUtils;
 
-    @Autowired
-    private ProgramRepository programRepository;
+        @Autowired
+        private BCryptPasswordEncoder passwordEncoder;
 
-    @Autowired
-    private LessonRepository lessonRepository;
+        @Autowired
+        private ProgramRepository programRepository;
 
-    @Autowired
-    private UserProgramProgressRepository userProgramProgressRepository;
+        @Autowired
+        private LessonRepository lessonRepository;
 
-    @Autowired
-    private UserLessonProgressRepository userLessonProgressRepository;
+        @Autowired
+        private UserProgramProgressRepository userProgramProgressRepository;
 
+        @Autowired
+        private UserLessonProgressRepository userLessonProgressRepository;
 
-    private static final String CANDIDATE_EMAIL = "candidate_user@example.com";
-    private String candidateToken;
-    private User testUser;
-    private Program testProgram;
-    private Lesson testLesson;
-    private UserProgramProgress testProgramProgress;
-    private User anotherUser;
-    private String anotherToken;
-    private static final String ANOTHER_EMAIL = "another_user@example.com";
-
-
-    @AfterEach
-    void cleanUp() {
-        userLessonProgressRepository.deleteAll();
-        userProgramProgressRepository.deleteAll();
-        lessonRepository.deleteAll();
-        programRepository.deleteAll();
-        userRepository.deleteAll();
-    }
-
-    @BeforeEach
-    void setUp() {
-        cleanUp();
-
-        testUser = new User();
-        testUser.setEmail(CANDIDATE_EMAIL);
-        testUser.setEncryptedPassword(passwordEncoder.encode("candidate_password"));
-        testUser.setRole(RoleType.CANDIDATE);
-        testUser = userRepository.save(testUser);
-
-        candidateToken = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
-
-        anotherUser = new User();
-        anotherUser.setEmail(ANOTHER_EMAIL);
-        anotherUser.setEncryptedPassword(passwordEncoder.encode("another_password"));
-        anotherUser.setRole(RoleType.CANDIDATE);
-        anotherUser = userRepository.save(anotherUser);
-        anotherToken = jwtUtils.generateAccessToken(ANOTHER_EMAIL);
-
-        testProgram = new Program();
-        testProgram.setTitle("Test Program");
-        testProgram.setDescription("Test Program Description");
-        testProgram = programRepository.save(testProgram);
-
-        testLesson = new Lesson();
-        testLesson.setTitle("Test Lesson");
-        testLesson.setContent("Test Lesson Content");
-        testLesson.setProgram(testProgram);
-        testLesson.setOrderNumber(1);
-        testLesson = lessonRepository.save(testLesson);
-
-        testProgramProgress =  new UserProgramProgress();
-        testProgramProgress.setUser(testUser);
-        testProgramProgress.setProgram(testProgram);
-        testProgramProgress.setStartedAt(LocalDateTime.now());
-        testProgramProgress = userProgramProgressRepository.save(testProgramProgress);
-    }
-
-    @Test
-    void testCandidateAccessMyProgress() throws Exception {
-        mockMvc.perform(get("/account/my-progress")
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    void testCandidateAccessMyProgressWithPagination() throws Exception {
-        MvcResult result = mockMvc.perform(get("/account/my-progress")
-                        .param("page", "0")
-                        .param("size", "5")
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String content = result.getResponse().getContentAsString();
-        assertThat(content).contains("progress");
-        assertThat(content).contains("pagination");
-    }
-
-    @Test
-    void testGetLessonProgressWithPagination() throws Exception {
-        for (int i = 0; i < 3; i++) {
-            Lesson lesson = new Lesson();
-            lesson.setTitle("Test Lesson " + i);
-            lesson.setContent("Test Lesson Content " + i);
-            lesson.setProgram(testProgram);
-            lesson.setOrderNumber(i + 2);
-            lesson = lessonRepository.save(lesson);
-
-            UserLessonProgress lessonProgress = new UserLessonProgress();
-            lessonProgress.setUser(testUser);
-            lessonProgress.setLesson(lesson);
-            lessonProgress.setProgramProgress(testProgramProgress);
-            lessonProgress.setStartedAt(LocalDateTime.now());
-            lessonProgress.setIsCompleted(i % 2 == 0);
-            userLessonProgressRepository.save(lessonProgress);
+        @AfterEach
+        void cleanUp() {
+            userLessonProgressRepository.deleteAll();
+            userProgramProgressRepository.deleteAll();
+            lessonRepository.deleteAll();
+            programRepository.deleteAll();
+            userRepository.deleteAll();
         }
 
-        MvcResult result = mockMvc.perform(get("/account/my-progress/program/{programProgressId}/lessons",
-                        testProgramProgress.getId())
-                        .param("page", "0")
-                        .param("size", "2")
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isOk())
-                .andReturn();
+        private User createUser(String emailPrefix, String role) {
+            User user = new User();
+            String uniqueEmail = emailPrefix + "_" + System.currentTimeMillis() + "_" + Math.random() + "@example.com";
+            user.setEmail(uniqueEmail);
+            user.setRole(RoleType.valueOf(role));
+            user.setEncryptedPassword(passwordEncoder.encode("password"));
+            return userRepository.save(user);
+        }
 
-        String content = result.getResponse().getContentAsString();
-        assertThat(content).contains("lessonsProgress");
-        assertThat(content).contains("pagination");
+        private String generateToken(User user) {
+            return jwtUtils.generateAccessToken(user.getEmail());
+        }
+
+        private Program createProgram(String titlePrefix) {
+            Program program = new Program();
+            String uniqueTitle = titlePrefix + "_" + System.currentTimeMillis() + "_" + Math.random();
+            program.setTitle(uniqueTitle);
+            program.setDescription(uniqueTitle + "Description");
+            return programRepository.save(program);
+        }
+
+        private Lesson createLesson(Program program, String titlePrefix, int orderNumber) {
+            Lesson lesson = new Lesson();
+            String uniqueTitle = titlePrefix + "_" + System.currentTimeMillis() + "_" + Math.random();
+            lesson.setTitle(uniqueTitle);
+            lesson.setProgram(program);
+            lesson.setContent(uniqueTitle + "Content");
+            lesson.setOrderNumber(orderNumber);
+            return lessonRepository.save(lesson);
+        }
+
+        private UserProgramProgress createProgramProgress(User user, Program program) {
+            UserProgramProgress progress = new UserProgramProgress();
+            progress.setUser(user);
+            progress.setProgram(program);
+            progress.setStartedAt(LocalDateTime.now());
+            progress.setCompletedLessons(0);
+            progress.setIsCompleted(false);
+            return userProgramProgressRepository.save(progress);
+        }
+
+        private UserLessonProgress createLessonProgress(User user, Lesson lesson, UserProgramProgress programProgress) {
+            UserLessonProgress progress = new UserLessonProgress();
+            progress.setUser(user);
+            progress.setLesson(lesson);
+            progress.setProgramProgress(programProgress);
+            progress.setStartedAt(LocalDateTime.now());
+            progress.setIsCompleted(false);
+            progress.setTimeSpentMinutes(0);
+            return userLessonProgressRepository.save(progress);
+        }
+
+        @Test
+        void testCandidateAccessMyProgress() throws Exception {
+            // given
+            User user = createUser("candidate1", "CANDIDATE");
+            String token = generateToken(user);
+
+            // when
+            ResultActions result =  mockMvc.perform(get("/account/my-progress")
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"));
+            // then
+            result.andExpect(status().isOk());
+        }
+
+        @Test
+        void testCandidateAccessMyProgressWithPagination() throws Exception {
+            // given
+            User user = createUser("candidate2", "CANDIDATE");
+            String token = generateToken(user);
+
+            // when
+            MvcResult result = mockMvc.perform(get("/account/my-progress")
+                            .param("page", "0")
+                            .param("size", "5")
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // then
+            String content = result.getResponse().getContentAsString();
+            assertThat(content).contains("progress");
+            assertThat(content).contains("pagination");
+        }
+
+        @Test
+        void testGetLessonProgressWithPagination() throws Exception {
+            // given
+            User user = createUser("candidate3", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+
+            for (int i = 0; i < 3; i++) {
+                Lesson lesson = createLesson(program, "Lesson " + i, i);
+                UserLessonProgress lessonProgress = createLessonProgress(user, lesson, programProgress);
+
+                if (i % 2 == 0) {
+                    lessonProgress.setIsCompleted(true);
+                    lessonProgress.setCompletedAt(LocalDateTime.now());
+                    userLessonProgressRepository.save(lessonProgress);
+                }
+            }
+
+            // when
+            MvcResult result = mockMvc.perform(get("/account/my-progress/program/{programProgressId}/lessons",
+                            programProgress.getId())
+                            .param("page", "0")
+                            .param("size", "2")
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // then
+            String content = result.getResponse().getContentAsString();
+            assertThat(content).contains("lessonsProgress");
+            assertThat(content).contains("pagination");
+        }
+
+        @Test
+        void testGetLessonProgressWithDefaultPagination() throws Exception {
+            // given
+            User user = createUser("candidate4", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+            Lesson lesson = createLesson(program, "Lesson", 1);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/account/my-progress/program/{programProgressId}/lessons",
+                            programProgress.getId())
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"));
+            // then
+            result.andExpect(status().isOk());
+        }
+
+
+        @Test
+        void testStartProgram() throws Exception {
+            // given
+            User user = createUser("candidat5", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test program");
+
+            // when
+            mockMvc.perform(post("/account/my-progress/program/start")
+                            .param("programId", program.getId().toString())
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isFound());
+
+            // then
+            Optional<UserProgramProgress> progress = userProgramProgressRepository
+                    .findByUserIdAndProgramId(user.getId(), program.getId());
+            assertThat(progress).isPresent();
+            assertThat(progress.get().getStartedAt()).isNotNull();
+            assertThat(progress.get().getIsCompleted()).isFalse();
+        }
+
+        @Test
+        void testStartLesson() throws Exception {
+            // given
+            User user = createUser("candidate6", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+            Lesson lesson = createLesson(program, "Lesson", 1);
+
+            // when
+            mockMvc.perform(post("/account/my-progress/lesson/start")
+                            .param("programProgressId", programProgress.getId().toString())
+                            .param("lessonId", lesson.getId().toString())
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isFound());
+
+            // then
+            Optional<UserLessonProgress> lessonProgress = userLessonProgressRepository
+                    .findByUserIdAndLessonId(user.getId(), lesson.getId());
+            assertThat(lessonProgress).isPresent();
+            assertThat(lessonProgress.get().getStartedAt()).isNotNull();
+            assertThat(lessonProgress.get().getProgramProgress().getId()).isEqualTo(programProgress.getId());
+            assertThat(lessonProgress.get().getIsCompleted()).isFalse();
+        }
+
+
+        @Test
+        void testCompleteLesson() throws Exception {
+            // given
+            User user = createUser("candidate7", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test Program");
+            Lesson lesson = createLesson(program, "Test Lesson", 1);
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+            UserLessonProgress lessonProgress = createLessonProgress(user, lesson, programProgress);
+
+            // when
+            mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
+                            .param("programProgressId", programProgress.getId().toString())
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isFound());
+
+            // then
+            Optional<UserLessonProgress> completedLesson = userLessonProgressRepository
+                    .findById(lessonProgress.getId());
+
+            assertThat(completedLesson).isPresent();
+            assertThat(completedLesson.get().getCompletedAt()).isNotNull();
+            assertThat(completedLesson.get().getIsCompleted()).isTrue();
+        }
+
+
+        @Test
+        void testCompleteProgram() throws Exception {
+            // given
+            User user = createUser("candidate8", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test Program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+
+            // when
+            mockMvc.perform(post("/account/my-progress/program/" + programProgress.getId() + "/complete")
+                            .param("programProgressId", programProgress.getId().toString())
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"))
+                    .andExpect(status().isFound());
+
+            // then
+            Optional<UserProgramProgress> completedProgram = userProgramProgressRepository
+                    .findByUserIdAndProgramId(user.getId(), program.getId());
+            assertThat(completedProgram).isPresent();
+            assertThat(completedProgram.get().getCompletedAt()).isNotNull();
+            assertThat(completedProgram.get().getIsCompleted()).isTrue();
+        }
+
+        @Test
+        void testDefaultSectionRedirect() throws Exception {
+            // given
+            User user = createUser("candidate9", "CANDIDATE");
+            String token = generateToken(user);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/account/my-progress/")
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"));
+
+            // then
+            result.andExpect(status().is3xxRedirection());
+        }
+
+        @Test
+        void testCompletedLessonsCount() {
+            // given
+            User user = createUser("candidate10", "CANDIDATE");
+            Program program = createProgram("Test Program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+            for (int i = 0; i < 2; i++) {
+                Lesson lesson = createLesson(program, "Lesson " + i, i);
+                UserLessonProgress lessonProgress = createLessonProgress(user, lesson, programProgress);
+                lessonProgress.setIsCompleted(true);
+                lessonProgress.setCompletedAt(LocalDateTime.now());
+                userLessonProgressRepository.save(lessonProgress);
+            }
+
+            // when
+            var completedCount = userLessonProgressRepository
+                    .countCompletedLessonsByProgramProgressId(programProgress.getId());
+
+            // then
+            assertThat(completedCount).isEqualTo(2L);
+        }
+
+        @Test
+        void testGetProgressWithoutAuthentication() throws Exception {
+            // given - нет токена
+
+            // when
+            ResultActions result = mockMvc.perform(get("/account/my-progress")
+                            .header("X-Inertia", "true"));
+
+            // then
+            result.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void testGetProgressWithAuthentication() throws Exception {
+            // given
+            User user = createUser("candidate11", "CANDIDATE");
+            String token = generateToken(user);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/account/my-progress")
+                            .cookie(new Cookie("access_token", token))
+                            .header("X-Inertia", "true"));
+            // then
+            result.andExpect(status().isOk());
+        }
+
+        @Test
+        void completeLessonByAnotherUserReturnsForbidden() throws Exception {
+            // given
+            User user = createUser("candidate12", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test Program");
+            Lesson lesson = createLesson(program, "Test Lesson", 1);
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+            UserLessonProgress lessonProgress = createLessonProgress(user, lesson, programProgress);
+
+            User anotherUser = createUser("another1", "CANDIDATE");
+            String anotherToken = generateToken(anotherUser);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
+                    .param("programProgressId", programProgress.getId().toString())
+                    .cookie(new Cookie("access_token", anotherToken))
+                    .header("X-Inertia", true));
+
+            // then
+            result.andExpect(status().isForbidden());
+        }
+
+        @Test
+        void completeProgramByAnotherUserReturnsForbidden() throws Exception {
+            // given
+            User user = createUser("candidate13", "CANDIDATE");
+            String token = generateToken(user);
+            Program program = createProgram("Test Program");
+            UserProgramProgress programProgress = createProgramProgress(user, program);
+
+            User anotherUser = createUser("another2", "CANDIDATE");
+            String anotherToken = generateToken(anotherUser);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/account/my-progress/program/" + programProgress.getId() + "/complete")
+                            .param("programProgressId", programProgress.getId().toString())
+                            .cookie(new Cookie("access_token", anotherToken))
+                            .header("X-Inertia", true));
+            // then
+            result.andExpect(status().isForbidden());
+        }
     }
-
-    @Test
-    void testGetLessonProgressWithDefaultPagination() throws Exception {
-        mockMvc.perform(get("/account/my-progress/program/{programProgressId}/lessons",
-                        testProgramProgress.getId())
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isOk());
-    }
-
-
-    @Test
-    void testStartProgram() throws Exception {
-        mockMvc.perform(post("/account/my-progress/program/start")
-                        .param("programId", testProgram.getId().toString())
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isFound());
-
-        Optional<UserProgramProgress> progress = userProgramProgressRepository
-                .findByUserIdAndProgramId(testUser.getId(), testProgram.getId());
-        assertThat(progress).isPresent();
-        assertThat(progress.get().getStartedAt()).isNotNull();
-    }
-
-    @Test
-    void testStartLesson() throws Exception {
-        mockMvc.perform(post("/account/my-progress/lesson/start")
-                        .param("programProgressId", testProgramProgress.getId().toString())
-                        .param("lessonId", testLesson.getId().toString())
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isFound());
-
-        Optional<UserLessonProgress> lessonProgress = userLessonProgressRepository
-                .findByUserIdAndLessonId(testUser.getId(), testLesson.getId());
-        assertThat(lessonProgress).isPresent();
-        assertThat(lessonProgress.get().getStartedAt()).isNotNull();
-        assertThat(lessonProgress.get().getProgramProgress().getId()).isEqualTo(testProgramProgress.getId());
-    }
-
-
-    @Test
-    void testCompleteLesson() throws Exception {
-        UserLessonProgress lessonProgress = new UserLessonProgress();
-        lessonProgress.setUser(testUser);
-        lessonProgress.setLesson(testLesson);
-        lessonProgress.setProgramProgress(testProgramProgress);
-        lessonProgress.setStartedAt(LocalDateTime.now());
-        lessonProgress.setIsCompleted(false);
-        lessonProgress = userLessonProgressRepository.save(lessonProgress);
-
-        mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
-                        .param("programProgressId", testProgramProgress.getId().toString())
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isFound());
-
-        Optional<UserLessonProgress> completedLesson = userLessonProgressRepository
-                .findById(lessonProgress.getId());
-
-        assertThat(completedLesson).isPresent();
-        assertThat(completedLesson.get().getCompletedAt()).isNotNull();
-        assertThat(completedLesson.get().getIsCompleted()).isTrue();
-    }
-
-
-    @Test
-    void testCompleteProgram() throws Exception {
-        mockMvc.perform(post("/account/my-progress/program/" + testProgramProgress.getId() + "/complete")
-                        .param("programProgressId", testProgramProgress.getId().toString())
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isFound());
-
-        Optional<UserProgramProgress> completedProgram = userProgramProgressRepository
-                .findByUserIdAndProgramId(testUser.getId(), testProgram.getId());
-        assertThat(completedProgram).isPresent();
-        assertThat(completedProgram.get().getCompletedAt()).isNotNull();
-        assertThat(completedProgram.get().getIsCompleted()).isTrue();
-    }
-
-    @Test
-    void testDefaultSectionRedirect() throws Exception {
-        var token = jwtUtils.generateAccessToken(CANDIDATE_EMAIL);
-
-        mockMvc.perform(get("/account/my-progress/")
-                        .cookie(new Cookie("access_token", token))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().is3xxRedirection());
-    }
-
-    @Test
-    void testCompletedLessonsCount() {
-        UserLessonProgress userLessonProgress = new UserLessonProgress();
-        userLessonProgress.setUser(testUser);
-        userLessonProgress.setLesson(testLesson);
-        userLessonProgress.setProgramProgress(testProgramProgress);
-        userLessonProgress.setStartedAt(LocalDateTime.now());
-        userLessonProgress.setCompletedAt(LocalDateTime.now());
-        userLessonProgress.setIsCompleted(true);
-        userLessonProgressRepository.save(userLessonProgress);
-
-        var testLesson2 = new Lesson();
-        testLesson2.setTitle("Test Lesson 2");
-        testLesson2.setContent("Test Lesson Content 2");
-        testLesson2.setProgram(testProgram);
-        testLesson2.setOrderNumber(2);
-        testLesson2 = lessonRepository.save(testLesson2);
-
-        var userLessonProgress1 = new UserLessonProgress();
-        userLessonProgress1.setUser(testUser);
-        userLessonProgress1.setLesson(testLesson2);
-        userLessonProgress1.setProgramProgress(testProgramProgress);
-        userLessonProgress1.setStartedAt(LocalDateTime.now());
-        userLessonProgress1.setCompletedAt(LocalDateTime.now());
-        userLessonProgress1.setIsCompleted(true);
-        userLessonProgressRepository.save(userLessonProgress1);
-
-        var completedCount = userLessonProgressRepository
-                .countCompletedLessonsByProgramProgressId(testProgramProgress.getId());
-        assertThat(completedCount).isEqualTo(2L);
-    }
-
-    @Test
-    void testGetProgressWithoutAuthentication() throws Exception {
-        mockMvc.perform(get("/account/my-progress")
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void testGetProgressWithAuthentication() throws Exception {
-        mockMvc.perform(get("/account/my-progress")
-                        .cookie(new Cookie("access_token", candidateToken))
-                        .header("X-Inertia", "true"))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    void completeLessonByAnotherUserReturnsForbidden() throws Exception {
-        UserLessonProgress lessonProgress = new UserLessonProgress();
-        lessonProgress.setUser(testUser);
-        lessonProgress.setLesson(testLesson);
-        lessonProgress.setProgramProgress(testProgramProgress);
-        lessonProgress.setStartedAt(LocalDateTime.now());
-        lessonProgress.setIsCompleted(false);
-        lessonProgress = userLessonProgressRepository.save(lessonProgress);
-
-        mockMvc.perform(post("/account/my-progress/lesson/" + lessonProgress.getId() + "/complete")
-                .param("programProgressId", testProgramProgress.getId().toString())
-                .cookie(new Cookie("access_token", anotherToken))
-                .header("X-Inertia", true))
-                .andExpect(status().isForbidden());
-    }
-
-    @Test
-    void completeProgramByAnotherUserReturnsForbidden() throws Exception {
-        mockMvc.perform(post("/account/my-progress/program/" + testProgramProgress.getId() + "/complete")
-                        .param("programProgressId", testProgramProgress.getId().toString())
-                        .cookie(new Cookie("access_token", anotherToken))
-                        .header("X-Inertia", true))
-                .andExpect(status().isForbidden());
-    }
-}


### PR DESCRIPTION
Closes #1057
- Добавлена проверка прав доступа при завершении уроков и программ обучения. Теперь пользователь может завершить только свой собственный прогресс
- Ранее любой аутентифицированный пользователь мог завершить урок или программу другого пользователя, зная ID прогресса.
- В `UserLessonProgressService.completeLesson()` добавлена проверка: `progress.getUser().getId().equals(userId)`
- В `UserProgramProgressService.completeProgram()` добавлена аналогичная проверка
- Добавлено 2 теста для проверки с чужим пользователем
- В GlobalExceptionHandler добавлена обработка AccessDeniedException с возвратом HTTP статуса 403 Forbidden