### PR TITLE
[feat-1080] переименована опечатка UserPageSercive наUserPageService

### DIFF
--- a/src/main/java/io/hexlet/cv/controller/UserPageController.java
+++ b/src/main/java/io/hexlet/cv/controller/UserPageController.java
@@ -3,7 +3,7 @@ package io.hexlet.cv.controller;
 import io.github.inertia4j.spring.Inertia;
 import io.hexlet.cv.handler.exception.UserNotFoundException;
 import io.hexlet.cv.service.FlashPropsService;
-import io.hexlet.cv.service.UserPageSercive;
+import io.hexlet.cv.service.UserPageService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -19,7 +19,7 @@ public class UserPageController {
 
     private final Inertia inertia;
     private final FlashPropsService flashPropsService;
-    private final UserPageSercive userPageService;
+    private final UserPageService userPageService;
 
     @GetMapping("/users/{user_id}")
     public ResponseEntity<?> userPage(

--- a/src/main/java/io/hexlet/cv/service/UserPageService.java
+++ b/src/main/java/io/hexlet/cv/service/UserPageService.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
-public class UserPageSercive {
+public class UserPageService {
 
     private UserRepository userRepository;
     private ResumeRepository resumeRepository;


### PR DESCRIPTION
Исправлена опечатка в названии класса 
UserPageService.java ):
// было: public class UserPageSercive {
// стало: public class UserPageService {

Обновлены ссылки UserPageController.java
// было:
import io.hexlet.cv.service.UserPageSercive;
private final UserPageSercive userPageService;

// стало:
import io.hexlet.cv.service.UserPageService;
private final UserPageService userPageService;