### PR TITLE
[Feat-1083] fix: отключен show-sql для production

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,7 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
 
 app:
   security:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,4 +7,4 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-
+    show-sql: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,6 @@ spring:
       write-dates-as-timestamps: false
 
   jpa:
-    show-sql: true
     generate-ddl: true
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
       write-dates-as-timestamps: false
 
   jpa:
+    show-sql: false
     generate-ddl: true
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
Closes #1083

- Заменен`show-sql: true` из `application.yml` на `show-sql: false`
- Добавлен `show-sql: true` в `application-dev.yml`
- Добавлен `show-sql: false` в `application-prod.yml`

Теперь SQL запросы не выводятся в консоль на production, но продолжают выводиться в development окружении. В production улучшится производительность, в консоли не будут выводится SQL запросы содержащие данные пользователей (улучшится безопасность), логи станут чище и не будут заполнять память.