### PR TITLE
[Feat-1082] fix: Скрыты детали внутренних ошибок от клиентов 

### DIFF
--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -125,9 +128,12 @@ public class GlobalExceptionHandler {
 
 // это просто ошибки все остальное
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleAll(Exception ex) {
-        Map<String, String> errors = Map.of("error", ex.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Map.of("errors", errors));
+    public Object handleAll(Exception ex,
+                            HttpServletRequest request,
+                            RedirectAttributes redirectAttributes) {
+        log.error("Internal server error", ex);
+
+        Map<String, String> errors = Map.of("error", "Internal server error");
+        return commonHandle(errors, request, redirectAttributes, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
Closes #1082

- Добавлена аннотация Lombok @Slf4j для логирования
- Добавлено логирование полной ошибки через `log.error()`
- Клиенту возвращается generic сообщение "Internal server error"
- Учтена поддержка Inertia через `commonHandle()`