### PR TITLE
[FEAT-1084] Добавлен Dockerfile, .dockerignore и обновлен README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,22 @@
-.git
-vendor
-node_modules
-log
-tmp
+# Gradle cache и результаты сборки
+.gradle/
+build/
+
+# Frontend зависимости и сборка
+frontend/node_modules/
+frontend/dist/
+node_modules/
+
+# Git
+.git/
+.gitignore
+
+# Документация и конфиги IDE
+*.md
+.idea/
+*.iml
+*.iws
+
+# Секреты
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1 : build
+FROM eclipse-temurin:24-jdk AS builder
+WORKDIR /app
+
+COPY gradlew gradlew.bat ./
+COPY gradle/ gradle/
+COPY build.gradle.kts settings.gradle.kts gradle.properties versions.properties ./
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon 2>/dev/null; true
+
+COPY src/ src/
+RUN ./gradlew bootJar --no-daemon -x test
+
+# Stage 2 : runtime
+FROM eclipse-temurin:24-jre AS runtime
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/libs/hexlet-cv-1.0-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -6,4 +6,24 @@ The project - online service to create and publish CV. It is oriented on IT-spec
 The platform will help users to create professional CV promptly and get link of it to send employers.
 
 use [ https://github.com/Inertia4J/inertia4j ]
+
+## Docker
+
+```bash
+# Сборка образа
+docker build -t hexlet-cv .
+
+# Запуск (dev, H2)
+docker run -p 8080:8080 hexlet-cv
+
+# Запуск (prod, PostgreSQL)
+docker run -p 8080:8080 \
+  -e SPRING_PROFILES_ACTIVE=prod \
+  -e JDBC_DATABASE_URL=jdbc:postgresql://host:5432/db \
+  -e USERNAME=user \
+  -e PASSWORD=secret \
+  hexlet-cv
+
+# Проверка healthcheck
+curl http://localhost:8080/actuator/health
  


### PR DESCRIPTION
Closes #1084

1. Dockerfile с multi-stage сборкой, сделан в два этапа:
Первый этап (builder) - используем большой JDK, чтобы скомпилировать код и собрать JAR-файл
Второй этап (runtime) - берём только JAR-файл из первого этапа и запускаем на маленьком JRE
   
2. .dockerignore - исключаю лишнее: .git, build, node_modules, .env

3. Добавил в README.md раздел с командами для сборки и запуска

Выполнил проверку, сборка прошла успешно
docker build -t hexlet-cv .

Контейнер запускается и отвечает на порту 8080
docker run -p 8080:8080 hexlet-cv

Проверка Healthcheck работает
curl http://localhost:8080/actuator/health
{"status":"UP"}