### PR TITLE
[FEAT-897] компонент личного кабинета с меню

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,13 @@ build
 .settings
 .class
 .PVS-Studio/
+
+# IDE
+.vscode/
+.specstory/
+
+# Configs
+config.json
+
+# Docs
+docs/*review*.md

--- a/src/main/java/io/hexlet/cv/controller/KnowledgeController.java
+++ b/src/main/java/io/hexlet/cv/controller/KnowledgeController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,12 +28,11 @@ public class KnowledgeController {
 
     private final KnowledgeService knowledgeService;
     private final Inertia inertia;
-    private final ControllerUtils utils;
     private final AccountPageRenderer accountPageRenderer;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public Object getKnowledgeHome() {
+    public ResponseEntity<?> getKnowledgeHome() {
         log.debug("[KNOWLEDGE CONTROLLER] Get knowledge home request");
 
         var recentArticles = knowledgeService.getRecentArticles(RECENT_KNOWLEDGE_ITEMS_LIMIT);
@@ -47,19 +47,12 @@ public class KnowledgeController {
 
     @GetMapping("/articles")
     @ResponseStatus(HttpStatus.OK)
-    public Object getArticles(@RequestParam(required = false) String category,
+    public ResponseEntity<?> getArticles(@RequestParam(required = false) String category,
                               @PageableDefault Pageable pageable) {
         log.debug("[KNOWLEDGE CONTROLLER] Get all articles, category: {}, page: {}",
                 category, pageable.getPageNumber());
 
-        var articlesPage = knowledgeService.getArticles(category, pageable);
-
-        Map<String, Object> pageProps = new HashMap<>();
-        pageProps.put("articles", articlesPage.getContent());
-        pageProps.put("pagination", utils.createPaginationMap(articlesPage, pageable));
-        if (category != null && !category.isBlank()) {
-            pageProps.put("selectedCategory", category);
-        }
+        Map<String, Object> pageProps = knowledgeService.buildArticlesPageProps(category, pageable);
 
         return accountPageRenderer.render("Account/Knowledge/Articles/Index",
                 "knowledgeArticles", pageProps);
@@ -67,7 +60,7 @@ public class KnowledgeController {
 
     @GetMapping("/articles/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public Object getArticleById(@PathVariable Long id) {
+    public ResponseEntity<?> getArticleById(@PathVariable Long id) {
         log.debug("[KNOWLEDGE CONTROLLER] Get article by id: {}", id);
 
         var article = knowledgeService.getArticleById(id);
@@ -81,19 +74,12 @@ public class KnowledgeController {
 
     @GetMapping("/interviews")
     @ResponseStatus(HttpStatus.OK)
-    public Object getAllInterviews(@RequestParam(required = false) String category,
+    public ResponseEntity<?> getAllInterviews(@RequestParam(required = false) String category,
                                    @PageableDefault Pageable pageable) {
         log.debug("[KNOWLEDGE CONTROLLER] Get all interviews, category: {}, page: {}",
                 category, pageable.getPageNumber());
 
-        var interviewsPage = knowledgeService.getInterviews(category, pageable);
-
-        Map<String, Object> pageProps = new HashMap<>();
-        pageProps.put("interviews", interviewsPage.getContent());
-        if (category != null && !category.isBlank()) {
-            pageProps.put("selectedCategory", category);
-        }
-        pageProps.put("pagination", utils.createPaginationMap(interviewsPage, pageable));
+        Map<String, Object> pageProps = knowledgeService.buildInterviewsPageProps(category, pageable);
 
         return accountPageRenderer.render("Account/Knowledge/Interviews/Index",
                 "knowledgeInterviews", pageProps);
@@ -101,7 +87,7 @@ public class KnowledgeController {
 
     @GetMapping("/interviews/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public Object getInterviewById(@PathVariable Long id) {
+    public ResponseEntity<?> getInterviewById(@PathVariable Long id) {
         log.debug("[KNOWLEDGE CONTROLLER] Get interview by id: {}", id);
 
         var interview = knowledgeService.getInterviewById(id);
@@ -114,7 +100,7 @@ public class KnowledgeController {
     }
 
     @GetMapping("/")
-    public Object defaultRedirect() {
+    public ResponseEntity<?> defaultRedirect() {
         log.debug("[KNOWLEDGE CONTROLLER] Redirect from /account/knowledge/ to /account/knowledge");
         return inertia.redirect("/account/knowledge");
     }

--- a/src/main/java/io/hexlet/cv/controller/KnowledgeController.java
+++ b/src/main/java/io/hexlet/cv/controller/KnowledgeController.java
@@ -2,6 +2,7 @@ package io.hexlet.cv.controller;
 
 import io.github.inertia4j.spring.Inertia;
 import io.hexlet.cv.service.KnowledgeService;
+import io.hexlet.cv.util.AccountPageRenderer;
 import io.hexlet.cv.util.ControllerUtils;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +28,7 @@ public class KnowledgeController {
     private final KnowledgeService knowledgeService;
     private final Inertia inertia;
     private final ControllerUtils utils;
+    private final AccountPageRenderer accountPageRenderer;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -36,11 +38,11 @@ public class KnowledgeController {
         var recentArticles = knowledgeService.getRecentArticles(RECENT_KNOWLEDGE_ITEMS_LIMIT);
         var recentInterviews = knowledgeService.getRecentInterviews(RECENT_KNOWLEDGE_ITEMS_LIMIT);
 
-        var props = new HashMap<>(utils.createAccountProps("knowledge"));
-        props.put("recentArticles", recentArticles);
-        props.put("recentInterviews", recentInterviews);
+        Map<String, Object> pageProps = Map.of(
+            "recentArticles", recentArticles,
+            "recentInterviews", recentInterviews);
 
-        return inertia.render("Account/Knowledge/Index", props);
+        return accountPageRenderer.render("Account/Knowledge/Index", "knowledge", pageProps);
     }
 
     @GetMapping("/articles")
@@ -52,12 +54,15 @@ public class KnowledgeController {
 
         var articlesPage = knowledgeService.getArticles(category, pageable);
 
-        var props = new HashMap<>(utils.createAccountProps("knowledge-articles"));
-        props.put("articles", articlesPage.getContent());
-        utils.addPropertyIfPresent(props, "selectedCategory", category);
-        props.put("pagination", utils.createPaginationMap(articlesPage, pageable));
+        Map<String, Object> pageProps = new HashMap<>();
+        pageProps.put("articles", articlesPage.getContent());
+        pageProps.put("pagination", utils.createPaginationMap(articlesPage, pageable));
+        if (category != null && !category.isBlank()) {
+            pageProps.put("selectedCategory", category);
+        }
 
-        return inertia.render("Account/Knowledge/Articles/Index", props);
+        return accountPageRenderer.render("Account/Knowledge/Articles/Index",
+                "knowledgeArticles", pageProps);
     }
 
     @GetMapping("/articles/{id}")
@@ -67,10 +72,11 @@ public class KnowledgeController {
 
         var article = knowledgeService.getArticleById(id);
 
-        var props = new HashMap<>(utils.createAccountProps("knowledge-articles"));
-        props.put("article", article);
+        Map<String, Object> pageProps = Map.of(
+            "article", article);
 
-        return inertia.render("Account/Knowledge/Articles/Show", props);
+        return accountPageRenderer.render("Account/Knowledge/Articles/Show",
+                "knowledgeArticles", pageProps);
     }
 
     @GetMapping("/interviews")
@@ -82,12 +88,15 @@ public class KnowledgeController {
 
         var interviewsPage = knowledgeService.getInterviews(category, pageable);
 
-        Map<String, Object> props = new HashMap<>(utils.createAccountProps("knowledge-interviews"));
-        props.put("interviews", interviewsPage.getContent());
-        utils.addPropertyIfPresent(props, "selectedCategory", category);
-        props.put("pagination", utils.createPaginationMap(interviewsPage, pageable));
+        Map<String, Object> pageProps = new HashMap<>();
+        pageProps.put("interviews", interviewsPage.getContent());
+        if (category != null && !category.isBlank()) {
+            pageProps.put("selectedCategory", category);
+        }
+        pageProps.put("pagination", utils.createPaginationMap(interviewsPage, pageable));
 
-        return inertia.render("Account/Knowledge/Interviews/Index", props);
+        return accountPageRenderer.render("Account/Knowledge/Interviews/Index",
+                "knowledgeInterviews", pageProps);
     }
 
     @GetMapping("/interviews/{id}")
@@ -97,10 +106,11 @@ public class KnowledgeController {
 
         var interview = knowledgeService.getInterviewById(id);
 
-        var props = new HashMap<>(utils.createAccountProps("knowledge-interviews"));
-        props.put("interview", interview);
+        Map<String, Object> pageProps = new HashMap<>();
+        pageProps.put("interview", interview);
 
-        return inertia.render("Account/Knowledge/Interviews/Show", props);
+        return accountPageRenderer.render("Account/Knowledge/Interviews/Show",
+                "knowledgeInterviews", pageProps);
     }
 
     @GetMapping("/")

--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -5,6 +5,7 @@ import io.hexlet.cv.dto.learning.UserLessonProgressDTO;
 import io.hexlet.cv.dto.learning.UserProgramProgressDTO;
 import io.hexlet.cv.service.UserLessonProgressService;
 import io.hexlet.cv.service.UserProgramProgressService;
+import io.hexlet.cv.util.ControllerUtils;
 import io.hexlet.cv.util.UserUtils;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -31,6 +32,7 @@ public class LearningProgressController {
     private final UserProgramProgressService userProgramProgressService;
     private final UserLessonProgressService userLessonProgressService;
     private final UserUtils userUtils;
+    private final ControllerUtils controllerUtils;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -41,17 +43,14 @@ public class LearningProgressController {
         Page<UserProgramProgressDTO> progressPage = userProgramProgressService.getUserProgress(user.getId(),
                 pageable);
 
-        Map<String, Object> props = Map.of(
-                "progress", progressPage.getContent(),
-                "pagination", Map.of(
+        Map<String, Object> props = controllerUtils.createAccountProps("my-progress");
+        props.put("progress", progressPage.getContent());
+        props.put("pagination", Map.of(
                         "currentPage", progressPage.getNumber(),
                         "totalPages", progressPage.getTotalPages(),
                         "totalElements", progressPage.getTotalElements(),
                         "pageSize", pageable.getPageSize()
-                ),
-                "activeMainSection", "account",
-                "activeSubSection", "my-progress"
-        );
+                ));
 
         log.debug("[CONTROLLER] Rendering Account/Learning/MyProgress/Index with {} "
                         + "programs and pagination",
@@ -69,18 +68,16 @@ public class LearningProgressController {
 
         Page<UserLessonProgressDTO> lessonsProgressPage = userLessonProgressService
                 .getLessonProgress(user.getId(), programProgressId, pageable);
-        Map<String, Object> props = Map.of(
-                "lessonsProgress", lessonsProgressPage.getContent(),
-                "pagination", Map.of(
-                        "currentPage", lessonsProgressPage.getNumber(),
-                        "totalPages", lessonsProgressPage.getTotalPages(),
-                        "totalElements", lessonsProgressPage.getTotalElements(),
-                        "pageSize", pageable.getPageSize()
-                ),
-                "programProgressId", programProgressId,
-                "activeMainSection", "account",
-                "activeSubSection", "my-progress"
+
+        Map<String, Object> props = controllerUtils.createAccountProps("my-progress");
+        props.put("lessonsProgress", lessonsProgressPage.getContent());
+        props.put("pagination", Map.of(
+                "currentPage", lessonsProgressPage.getNumber(),
+                "totalPages", lessonsProgressPage.getTotalPages(),
+                "totalElements", lessonsProgressPage.getTotalElements(),
+                "pageSize", pageable.getPageSize())
         );
+        props.put("programProgressId", programProgressId);
 
         log.debug("[CONTROLLER] Rendering a Lessons page {} lessons snd pagination",
                 lessonsProgressPage.getContent().size());

--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -6,6 +6,7 @@ import io.hexlet.cv.dto.learning.UserProgramProgressDTO;
 import io.hexlet.cv.service.UserLessonProgressService;
 import io.hexlet.cv.service.UserProgramProgressService;
 import io.hexlet.cv.util.AccountPageRenderer;
+import io.hexlet.cv.util.ControllerUtils;
 import io.hexlet.cv.util.UserUtils;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -33,6 +34,7 @@ public class LearningProgressController {
     private final UserLessonProgressService userLessonProgressService;
     private final UserUtils userUtils;
     private final AccountPageRenderer accountPageRenderer;
+    private final ControllerUtils utils;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -45,12 +47,7 @@ public class LearningProgressController {
 
         Map<String, Object> pageProps = Map.of(
                 "progress", progressPage.getContent(),
-                "pagination", Map.of(
-                        "currentPage", progressPage.getNumber(),
-                        "totalPages", progressPage.getTotalPages(),
-                        "totalElements", progressPage.getTotalElements(),
-                        "pageSize", pageable.getPageSize()
-                ));
+                "pagination", utils.createPaginationMap(progressPage, pageable));
 
         log.debug("[CONTROLLER] Rendering Account/Learning/MyProgress/Index with {} "
                         + "programs and pagination",
@@ -72,11 +69,7 @@ public class LearningProgressController {
 
         Map<String, Object> pageProps = Map.of(
             "lessonsProgress", lessonsProgressPage.getContent(),
-            "pagination", Map.of(
-                "currentPage", lessonsProgressPage.getNumber(),
-                "totalPages", lessonsProgressPage.getTotalPages(),
-                "totalElements", lessonsProgressPage.getTotalElements(),
-                "pageSize", pageable.getPageSize()),
+            "pagination", utils.createPaginationMap(lessonsProgressPage, pageable),
             "programProgressId", programProgressId);
 
         log.debug("[CONTROLLER] Rendering a Lessons page {} lessons snd pagination",

--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +39,7 @@ public class LearningProgressController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public Object getProgress(@PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<?> getProgress(@PageableDefault(size = 10) Pageable pageable) {
         log.debug("Get progress request");
         var user = userUtils.getCurrentUser();
 
@@ -58,7 +59,7 @@ public class LearningProgressController {
 
     @GetMapping("/program/{programProgressId}/lessons")
     @ResponseStatus(HttpStatus.OK)
-    public Object getLessonProgress(@PathVariable Long programProgressId,
+    public ResponseEntity<?> getLessonProgress(@PathVariable Long programProgressId,
                                     @PageableDefault(size = 10) Pageable pageable) {
         var user = userUtils.getCurrentUser();
         log.debug("[CONTROLLER] Getting lessons for programProgressId: {}, user: {}, pageable: {}",
@@ -79,7 +80,7 @@ public class LearningProgressController {
     }
 
     @PostMapping("/program/start")
-    public Object startProgram(@RequestParam Long programId) {
+    public ResponseEntity<?> startProgram(@RequestParam Long programId) {
         var user = userUtils.getCurrentUser();
         log.debug("[CONTROLLER] Program start {} by user {}", programId, user.getEmail());
 
@@ -88,7 +89,7 @@ public class LearningProgressController {
     }
 
     @PostMapping("/lesson/start")
-    public Object startLesson(@RequestParam Long programProgressId,
+    public ResponseEntity<?> startLesson(@RequestParam Long programProgressId,
                               @RequestParam Long lessonId) {
 
         var user = userUtils.getCurrentUser();
@@ -101,20 +102,20 @@ public class LearningProgressController {
     }
 
     @PostMapping("/lesson/{lessonProgressId}/complete")
-    public Object completeLesson(@PathVariable Long lessonProgressId,
+    public ResponseEntity<?> completeLesson(@PathVariable Long lessonProgressId,
                                  @RequestParam Long programProgressId) {
         userLessonProgressService.completeLesson(lessonProgressId);
         return inertia.redirect("/account/my-progress/program/" + programProgressId + "/lessons");
     }
 
     @PostMapping("/program/{programProgressId}/complete")
-    public Object completeProgram(@PathVariable Long programProgressId) {
+    public ResponseEntity<?> completeProgram(@PathVariable Long programProgressId) {
         userProgramProgressService.completeProgram(programProgressId);
         return inertia.redirect("/account/my-progress");
     }
 
     @GetMapping("/")
-    public Object defaultSection() {
+    public ResponseEntity<?> defaultSection() {
         log.debug("[CONTROLLER] GET /account/my-progress/ - Redirect to the main page");
         return inertia.redirect("/account/my-progress");
     }

--- a/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
+++ b/src/main/java/io/hexlet/cv/controller/LearningProgressController.java
@@ -5,7 +5,7 @@ import io.hexlet.cv.dto.learning.UserLessonProgressDTO;
 import io.hexlet.cv.dto.learning.UserProgramProgressDTO;
 import io.hexlet.cv.service.UserLessonProgressService;
 import io.hexlet.cv.service.UserProgramProgressService;
-import io.hexlet.cv.util.ControllerUtils;
+import io.hexlet.cv.util.AccountPageRenderer;
 import io.hexlet.cv.util.UserUtils;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -32,7 +32,7 @@ public class LearningProgressController {
     private final UserProgramProgressService userProgramProgressService;
     private final UserLessonProgressService userLessonProgressService;
     private final UserUtils userUtils;
-    private final ControllerUtils controllerUtils;
+    private final AccountPageRenderer accountPageRenderer;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -43,9 +43,9 @@ public class LearningProgressController {
         Page<UserProgramProgressDTO> progressPage = userProgramProgressService.getUserProgress(user.getId(),
                 pageable);
 
-        Map<String, Object> props = controllerUtils.createAccountProps("my-progress");
-        props.put("progress", progressPage.getContent());
-        props.put("pagination", Map.of(
+        Map<String, Object> pageProps = Map.of(
+                "progress", progressPage.getContent(),
+                "pagination", Map.of(
                         "currentPage", progressPage.getNumber(),
                         "totalPages", progressPage.getTotalPages(),
                         "totalElements", progressPage.getTotalElements(),
@@ -55,7 +55,8 @@ public class LearningProgressController {
         log.debug("[CONTROLLER] Rendering Account/Learning/MyProgress/Index with {} "
                         + "programs and pagination",
                 progressPage.getContent().size());
-        return inertia.render("Account/Learning/MyProgress/Index", props);
+        return accountPageRenderer.render("Account/Learning/MyProgress/Index",
+                "myProgress", pageProps);
     }
 
     @GetMapping("/program/{programProgressId}/lessons")
@@ -69,19 +70,19 @@ public class LearningProgressController {
         Page<UserLessonProgressDTO> lessonsProgressPage = userLessonProgressService
                 .getLessonProgress(user.getId(), programProgressId, pageable);
 
-        Map<String, Object> props = controllerUtils.createAccountProps("my-progress");
-        props.put("lessonsProgress", lessonsProgressPage.getContent());
-        props.put("pagination", Map.of(
+        Map<String, Object> pageProps = Map.of(
+            "lessonsProgress", lessonsProgressPage.getContent(),
+            "pagination", Map.of(
                 "currentPage", lessonsProgressPage.getNumber(),
                 "totalPages", lessonsProgressPage.getTotalPages(),
                 "totalElements", lessonsProgressPage.getTotalElements(),
-                "pageSize", pageable.getPageSize())
-        );
-        props.put("programProgressId", programProgressId);
+                "pageSize", pageable.getPageSize()),
+            "programProgressId", programProgressId);
 
         log.debug("[CONTROLLER] Rendering a Lessons page {} lessons snd pagination",
                 lessonsProgressPage.getContent().size());
-        return inertia.render("Account/Learning/MyProgress/Lessons", props);
+        return accountPageRenderer.render("Account/Learning/MyProgress/Lessons",
+                "myProgress", pageProps);
     }
 
     @PostMapping("/program/start")

--- a/src/main/java/io/hexlet/cv/controller/LoginController.java
+++ b/src/main/java/io/hexlet/cv/controller/LoginController.java
@@ -38,7 +38,7 @@ public class LoginController {
 
         var props = flashPropsService.buildProps(request);
 
-        return inertia.render("Users/SignIn", props);
+        return inertia.render("Users/SignIn/Index", props);
     }
 
     @PostMapping(path = "/users/sign_in")

--- a/src/main/java/io/hexlet/cv/controller/RegistrationController.java
+++ b/src/main/java/io/hexlet/cv/controller/RegistrationController.java
@@ -38,7 +38,7 @@ public class RegistrationController {
 
         var props = flashPropsService.buildProps(request);
 
-        return inertia.render("Users/SignUp", props);
+        return inertia.render("Users/SignUp/Index", props);
     }
 
     @PostMapping(path = "/users")

--- a/src/main/java/io/hexlet/cv/dto/account/MenuItemDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/account/MenuItemDTO.java
@@ -1,0 +1,4 @@
+package io.hexlet.cv.dto.account;
+
+public record MenuItemDTO(String label, String link) {
+}

--- a/src/main/java/io/hexlet/cv/dto/account/MenuItemDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/account/MenuItemDTO.java
@@ -1,4 +1,4 @@
 package io.hexlet.cv.dto.account;
 
-public record MenuItemDTO(String label, String link) {
+public record MenuItemDTO(String label, String link, String key) {
 }

--- a/src/main/java/io/hexlet/cv/dto/user/auth/RegistrationRequestDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/user/auth/RegistrationRequestDTO.java
@@ -8,6 +8,8 @@ import io.hexlet.cv.validator.PasswordNotSimilarToUser;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,4 +34,8 @@ public class RegistrationRequestDTO {
 
     @NotBlank(message = "{user.lastName.notBlank}")
     private String lastName;
+
+    @NotNull(message = "{user.terms.required}")
+    @AssertTrue(message = "{user.terms.accepted}")
+    private Boolean terms;
 }

--- a/src/main/java/io/hexlet/cv/service/AccountMenuService.java
+++ b/src/main/java/io/hexlet/cv/service/AccountMenuService.java
@@ -1,0 +1,28 @@
+package io.hexlet.cv.service;
+
+import io.hexlet.cv.dto.account.MenuItemDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AccountMenuService {
+    public List<MenuItemDTO> getMenu() {
+        return List.of(
+                new MenuItemDTO("Мое обучение", "/account/my-progress"),
+                new MenuItemDTO("Покупки и подписки", "/account/purchase"),
+                new MenuItemDTO("Вебинары", "/account/webinars"),
+                new MenuItemDTO("База знаний", "/account/knowledge"),
+                new MenuItemDTO("Интервью", null),
+                new MenuItemDTO("Грейдирование", null),
+                new MenuItemDTO("Программы обучения", "/account/programs"),
+                new MenuItemDTO("Резюме", null),
+                new MenuItemDTO("Сопроводительное", null),
+                new MenuItemDTO("Автоотклики", null),
+                new MenuItemDTO("Избранное", null),
+                new MenuItemDTO("Уведомления", "/account/notifications"),
+                new MenuItemDTO("Поддержка", null),
+                new MenuItemDTO("Настройки", null)
+        );
+    }
+}

--- a/src/main/java/io/hexlet/cv/service/AccountMenuService.java
+++ b/src/main/java/io/hexlet/cv/service/AccountMenuService.java
@@ -9,20 +9,20 @@ import java.util.List;
 public class AccountMenuService {
     public List<MenuItemDTO> getMenu() {
         return List.of(
-                new MenuItemDTO("Мое обучение", "/account/my-progress"),
-                new MenuItemDTO("Покупки и подписки", "/account/purchase"),
-                new MenuItemDTO("Вебинары", "/account/webinars"),
-                new MenuItemDTO("База знаний", "/account/knowledge"),
-                new MenuItemDTO("Интервью", null),
-                new MenuItemDTO("Грейдирование", null),
-                new MenuItemDTO("Программы обучения", "/account/programs"),
-                new MenuItemDTO("Резюме", null),
-                new MenuItemDTO("Сопроводительное", null),
-                new MenuItemDTO("Автоотклики", null),
-                new MenuItemDTO("Избранное", null),
-                new MenuItemDTO("Уведомления", "/account/notifications"),
-                new MenuItemDTO("Поддержка", null),
-                new MenuItemDTO("Настройки", null)
+                new MenuItemDTO("Мое обучение", "/account/my-progress", "myProgress"),
+                new MenuItemDTO("Покупки и подписки", "/account/purchase", "purchase"),
+                new MenuItemDTO("Вебинары", "/account/webinars", "webinars"),
+                new MenuItemDTO("База знаний", "/account/knowledge", "knowledge"),
+                new MenuItemDTO("Интервью", "/account/knowledge/interviews", "knowledgeInterviews"),
+                new MenuItemDTO("Грейдирование", null, null),
+                new MenuItemDTO("Программы обучения", "/account/programs", "programs"),
+                new MenuItemDTO("Резюме", null, null),
+                new MenuItemDTO("Сопроводительное", null, null),
+                new MenuItemDTO("Автоотклики", null, null),
+                new MenuItemDTO("Избранное", null, null),
+                new MenuItemDTO("Уведомления", "/account/notifications", "notifications"),
+                new MenuItemDTO("Поддержка", null, null),
+                new MenuItemDTO("Настройки", null, null)
         );
     }
 }

--- a/src/main/java/io/hexlet/cv/service/AccountSharedPropsResolver.java
+++ b/src/main/java/io/hexlet/cv/service/AccountSharedPropsResolver.java
@@ -1,0 +1,19 @@
+package io.hexlet.cv.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AccountSharedPropsResolver {
+
+    private final AccountMenuService accountMenuService;
+
+    public Map<String, Object> resolve(String activeMenuKey) {
+        return Map.of("account", Map.of(
+                "menu", accountMenuService.getMenu(),
+                "activeMenuKey", activeMenuKey
+        ));
+    }
+}

--- a/src/main/java/io/hexlet/cv/service/KnowledgeService.java
+++ b/src/main/java/io/hexlet/cv/service/KnowledgeService.java
@@ -6,8 +6,13 @@ import io.hexlet.cv.handler.exception.ResourceNotFoundException;
 import io.hexlet.cv.mapper.KnowledgeMapper;
 import io.hexlet.cv.repository.KnowledgeArticleRepository;
 import io.hexlet.cv.repository.KnowledgeInterviewRepository;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import io.hexlet.cv.util.ControllerUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -23,6 +28,7 @@ public class KnowledgeService {
     private final KnowledgeInterviewRepository knowledgeInterviewRepository;
     private final KnowledgeArticleRepository knowledgeArticleRepository;
     private final KnowledgeMapper knowledgeMapper;
+    private final ControllerUtils utils;
 
     @Transactional
     public Page<KnowledgeArticleDto> getArticles(String category, Pageable pageable) {
@@ -87,5 +93,29 @@ public class KnowledgeService {
                 .limit(limit)
                 .map(knowledgeMapper::toInterviewDTO)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Map<String, Object> buildArticlesPageProps(String category, Pageable pageable) {
+        var articlesPage = getArticles(category, pageable);
+        Map<String, Object> pageProps = new HashMap<>();
+        pageProps.put("articles", articlesPage.getContent());
+        pageProps.put("pagination", utils.createPaginationMap(articlesPage, pageable));
+        if (category != null && !category.isBlank()) {
+            pageProps.put("selectedCategory", category);
+        }
+        return pageProps;
+    }
+
+    @Transactional
+    public Map<String, Object> buildInterviewsPageProps(String category, Pageable pageable) {
+        Map<String, Object> pageProps = new HashMap<>();
+        var interviewsPage = getInterviews(category, pageable);
+        pageProps.put("interviews", interviewsPage.getContent());
+        pageProps.put("pagination", utils.createPaginationMap(interviewsPage, pageable));
+        if (category != null && !category.isBlank()) {
+            pageProps.put("selectedCategory", category);
+        }
+        return pageProps;
     }
 }

--- a/src/main/java/io/hexlet/cv/util/AccountPageRenderer.java
+++ b/src/main/java/io/hexlet/cv/util/AccountPageRenderer.java
@@ -1,0 +1,26 @@
+package io.hexlet.cv.util;
+
+import io.github.inertia4j.spring.Inertia;
+import io.hexlet.cv.service.AccountSharedPropsResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AccountPageRenderer {
+
+    private final Inertia inertia;
+    private final AccountSharedPropsResolver accountSharedPropsResolver;
+
+    public ResponseEntity<?> render(String component, String activeMenuKey, Map<String, Object> pageProps) {
+        Map<String, Object> sharedProps = accountSharedPropsResolver.resolve(activeMenuKey);
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.putAll(sharedProps);
+        allProps.putAll(pageProps);
+        return inertia.render(component, allProps);
+    }
+}

--- a/src/main/java/io/hexlet/cv/util/ControllerUtils.java
+++ b/src/main/java/io/hexlet/cv/util/ControllerUtils.java
@@ -1,6 +1,12 @@
 package io.hexlet.cv.util;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import io.hexlet.cv.dto.account.MenuItemDTO;
+import io.hexlet.cv.service.AccountMenuService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,12 +15,15 @@ import org.springframework.util.StringUtils;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class ControllerUtils {
 
     public static final String ACTIVE_MAIN_SECTION = "activeMainSection";
     public static final String ACTIVE_SUB_SECTION = "activeSubSection";
     public static final String MAIN_SECTION_MARKETING = "marketing";
     public static final String MAIN_SECTION_ACCOUNT = "account";
+
+    private final AccountMenuService accountMenuService;
 
     public Map<String, Object> createBaseProps(String mainSection, String subSection) {
         return Map.of(
@@ -34,7 +43,12 @@ public class ControllerUtils {
     }
 
     public Map<String, Object> createAccountProps(String subSection) {
-        return createBaseProps(MAIN_SECTION_ACCOUNT, subSection);
+        List<MenuItemDTO> menu = accountMenuService.getMenu();
+        Map<String, Object> props = new HashMap<>();
+        props.put(ACTIVE_MAIN_SECTION, MAIN_SECTION_ACCOUNT);
+        props.put(ACTIVE_SUB_SECTION, subSection);
+        props.put("menu", menu);
+        return props;
     }
 
     public Map<String, Object> createPaginationMap(Page<?> page, Pageable pageable) {

--- a/src/main/java/io/hexlet/cv/util/ControllerUtils.java
+++ b/src/main/java/io/hexlet/cv/util/ControllerUtils.java
@@ -11,7 +11,6 @@ import org.springframework.util.StringUtils;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class ControllerUtils {
 
     public static final String ACTIVE_MAIN_SECTION = "activeMainSection";

--- a/src/main/java/io/hexlet/cv/util/ControllerUtils.java
+++ b/src/main/java/io/hexlet/cv/util/ControllerUtils.java
@@ -1,11 +1,7 @@
 package io.hexlet.cv.util;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import io.hexlet.cv.dto.account.MenuItemDTO;
-import io.hexlet.cv.service.AccountMenuService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -22,8 +18,6 @@ public class ControllerUtils {
     public static final String ACTIVE_SUB_SECTION = "activeSubSection";
     public static final String MAIN_SECTION_MARKETING = "marketing";
     public static final String MAIN_SECTION_ACCOUNT = "account";
-
-    private final AccountMenuService accountMenuService;
 
     public Map<String, Object> createBaseProps(String mainSection, String subSection) {
         return Map.of(
@@ -43,12 +37,7 @@ public class ControllerUtils {
     }
 
     public Map<String, Object> createAccountProps(String subSection) {
-        List<MenuItemDTO> menu = accountMenuService.getMenu();
-        Map<String, Object> props = new HashMap<>();
-        props.put(ACTIVE_MAIN_SECTION, MAIN_SECTION_ACCOUNT);
-        props.put(ACTIVE_SUB_SECTION, subSection);
-        props.put("menu", menu);
-        return props;
+        return createBaseProps(MAIN_SECTION_ACCOUNT, subSection);
     }
 
     public Map<String, Object> createPaginationMap(Page<?> page, Pageable pageable) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,12 +17,12 @@ app:
   security:
     cookie:
       access:
-        httpOnly: false
+        httpOnly: true
         secure: false
-        sameSite: None          # можно откуда угодно
+        sameSite: Lax          # можно откуда угодно
         maxAgeSeconds: 900       # 15 минут
       refresh:
-        httpOnly: false
+        httpOnly: true
         secure: false
-        sameSite: None
+        sameSite: Lax
         maxAgeSeconds: 2592000   # 30 дней

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ app:
       access:
         httpOnly: true
         secure: false
-        sameSite: Lax          # можно откуда угодно
+        sameSite: Lax
         maxAgeSeconds: 900       # 15 минут
       refresh:
         httpOnly: true

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -15,6 +15,8 @@ user.lastName.notBlank=Last name is required
 user.alreadyExists=User with this email already exists
 user.notFound=User not found
 user.notFound.description=User with ID {0} does not exist in the system
+user.terms.required=Terms acceptance is required
+user.terms.accepted=You must accept the terms
 
 login.success=Login successful
 login.error=Invalid email or password

--- a/src/main/resources/messages/messages_ru.properties
+++ b/src/main/resources/messages/messages_ru.properties
@@ -15,6 +15,8 @@ user.lastName.notBlank=Фамилия обязательна
 user.alreadyExists=Пользователь с таким email уже существует
 user.notFound=Пользователь не найден
 user.notFound.description=Пользователь с ID {0} не существует в системе
+user.terms.required=Необходимо указать согласие с условиями
+user.terms.accepted=Необходимо принять условия
 
 login.success=Вход выполнен успешно
 login.error=Неверный email или пароль

--- a/src/test/java/io/hexlet/cv/controller/KnowledgeControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/KnowledgeControllerTest.java
@@ -139,8 +139,7 @@ public class KnowledgeControllerTest {
                 .contains("Published Interview 2")
                 .doesNotContain("Unpublished Article")
                 .doesNotContain("Unpublished Interview");
-        assertThat(response).contains("\"activeMainSection\":\"account\"");
-        assertThat(response).contains("\"activeSubSection\":\"knowledge\"");
+        assertThat(response).contains("\"activeMenuKey\":\"knowledge\"");
     }
 
     @Test
@@ -160,8 +159,7 @@ public class KnowledgeControllerTest {
                 .andExpect(jsonPath("$.props.pagination.totalPages").value(2))
                 .andExpect(jsonPath("$.props.pagination.pageSize").value(10))
                 .andExpect(jsonPath("$.props.selectedCategory").doesNotExist())
-                .andExpect(jsonPath("$.props.activeMainSection").value("account"))
-                .andExpect(jsonPath("$.props.activeSubSection").value("knowledge-articles"));
+                .andExpect(jsonPath("$.props.account.activeMenuKey").value("knowledgeArticles"));
     }
 
     @Test
@@ -181,8 +179,7 @@ public class KnowledgeControllerTest {
         assertThat(response)
                 .contains("\"title\":\"Test Article\"")
                 .contains("\"category\":\"SQL\"")
-                .contains("\"activeMainSection\":\"account\"")
-                .contains("\"activeSubSection\":\"knowledge-articles\"")
+                .contains("\"activeMenuKey\":\"knowledgeArticles\"")
                 .doesNotContain("Another Article");
     }
 
@@ -239,8 +236,7 @@ public class KnowledgeControllerTest {
                 .andExpect(jsonPath("$.props.pagination.totalPages").value(3))
                 .andExpect(jsonPath("$.props.pagination.pageSize").value(5))
                 .andExpect(jsonPath("$.props.selectedCategory").doesNotExist())
-                .andExpect(jsonPath("$.props.activeMainSection").value("account"))
-                .andExpect(jsonPath("$.props.activeSubSection").value("knowledge-interviews"));
+                .andExpect(jsonPath("$.props.account.activeMenuKey").value("knowledgeInterviews"));
     }
 
     @Test
@@ -261,8 +257,7 @@ public class KnowledgeControllerTest {
                 .contains("\"title\":\"Test Interview\"")
                 .contains("\"category\":\"Java\"")
                 .contains("\"questionsCount\":10")
-                .contains("\"activeMainSection\":\"account\"")
-                .contains("\"activeSubSection\":\"knowledge-interviews\"")
+                .contains("\"activeMenuKey\":\"knowledgeInterviews\"")
                 .doesNotContain("Another Interview");
     }
 

--- a/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class    RegistrationControllerTest {
+public class RegistrationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class RegistrationControllerTest {
+public class    RegistrationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -349,6 +349,7 @@ public class RegistrationControllerTest {
         dto.setPassword("test_password123");
         dto.setFirstName("firstName");
         dto.setLastName("lastName");
+        dto.setTerms(true);
         return dto;
     }
 }


### PR DESCRIPTION
- Создал новый рекорд класс dto/account/MenuItemDTO.java с полями label и link. Пункт меню
 
- Создал src/main/java/io/hexlet/cv/service/AccountMenuService.java, класс содержит метод getMenu который возвращает полный список пунктов меню. Пока без ролевки, полным списком. Те эндпоинты что есть в проекты уже вписана в поле link. Те что нет, пока null, не кликабельны.
 
- Добавил централизованный механизм для личного кабинета. Теперь меню и общие данные добавляются автоматически, а не в каждом контроллере вручную.

- Добавил класс AccountSharedPropsResolver который собирает все общие данные для личного кабинета. Берёт активный пункт меню ("myProgress") и возвращает Map с двумя полями под именем account.

- Класс AccountPageRenderer рендерер, который получает данные AccountSharedPropsResolver, объединяет общие данные и данные страницы и возвращает инетрия рендер.

Обновил:

LearningProgressController — теперь только свои данные, меню добавляется автоматически
KnowledgeController — тоже перевел на новый механизм
MenuItemDTO — добавил поле activeKey для подсветки активного пункта
AccountMenuService — добавил ключи для пунктов меню
ControllerUtils — убрал из него логику меню (теперь он только для пагинации и базовых пропсов)
Контроллеры стали проще без дублирования и ручного добавления пропсов.

Исправлена интеграция между фронтом и бэком в части форм логина и регистрации
Исправлена настройки кук для дева чтобы токены цеплялись к запросам с фронта автоматически

Обновлены тесты с учетом изменения формата пропсов.
